### PR TITLE
feature: adding metric evaluation agent using opik

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -102,3 +102,15 @@ Verify maestro is running properly: `maestro --help`
 ##### SlackBot support
 
 Please set `SLACK_BOT_TOKEN` and `SLACK_TEAM_ID` as environment variables. See `./tests/yamls/agents/slack_agent.yaml` and `./tests/yamls/workflow_agent.yaml` for details. The output of slack message will be whatever is passed into the prompt.
+
+##### Evaluation/Metrics Support
+
+The Metrics Agent integrates Opik's LLM as a judge metrics into our workflows. Automatically route `spec.model` in the agent definition and add to workflow to automatically evaluate using `AnswerRelevance` and `Hallucination` scores. 
+
+See `./tests/yamls/agents/metrics_agent.py` and `./tests/yamls/workflows/metrics_agents.py` for more details.
+
+There are 2 required exports as we use ollama for backend:
+```bash
+OPENAI_API_BASE=http://localhost:11434/v1
+OPENAI_API_KEY=ollama
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ beeai-framework = "^0.1.17"
 slack_sdk = "^3.35.0"
 nest-asyncio = "^1.6.0"
 pydantic-ai = {extras = ["logfire"], version = "^0.1.8"}
+opik = "^1.7.22"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/src/agents/agent_factory.py
+++ b/src/agents/agent_factory.py
@@ -9,6 +9,7 @@ from .remote_agent import RemoteAgent
 from .mock_agent import MockAgent
 from .custom_agent import CustomAgent
 from .slack_agent import SlackAgent
+from .metrics_agent import MetricsAgent
 
 class AgentFramework(StrEnum):
     """Enumeration of supported frameworks"""

--- a/src/agents/custom_agent.py
+++ b/src/agents/custom_agent.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from src.agents.agent import Agent
 from src.agents.slack_agent import SlackAgent
+from src.agents.metrics_agent import MetricsAgent
 
 # adding a custom agent
 # 1. add necessary import for the agent
@@ -17,7 +18,7 @@ from src.agents.slack_agent import SlackAgent
 # 1. set "custom" to "framework"
 # 2  set the custom agent name to "metadata.labels.custom_agent"
 
-custom_agent = { "slack_agent": SlackAgent }
+custom_agent = { "slack_agent": SlackAgent, "metrics_agent": MetricsAgent}
 
 class CustomAgent(Agent):
     """

--- a/src/agents/metrics_agent.py
+++ b/src/agents/metrics_agent.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from src.agents.agent import Agent
+from opik.evaluation.metrics import Hallucination, AnswerRelevance
+
+class MetricsAgent(Agent):
+    """
+    Generic agent that takes any two inputs (prompt & response)
+    and returns the original response plus Opik judge metrics.
+    """
+
+    def __init__(self, agent: dict) -> None:
+        super().__init__(agent)
+        # you could also read self.agent_config.get("metrics") here 
+        # to make it configurable via YAML
+        self._metrics = {
+            "relevance": AnswerRelevance(),
+            "hallucination": Hallucination()
+        }
+
+    async def run(self, prompt: str, response: str):
+        """
+        Args:
+          prompt:   the original input (e.g. location, user question)
+          response: the LLM’s output
+
+        Returns:
+          dict with:
+            - response: the original response
+            - relevance: float score ∈ [0,1]
+            - hallucination: float score ∈ [0,1]
+        """
+        scores = {}
+        for name, metric in self._metrics.items():
+            scores[name] = metric.score(
+                input=prompt,
+                output=response,
+                context=[f"Context: {prompt}"]
+            )
+
+        return {
+            "response": response,
+            **scores
+        }

--- a/tests/agents/test_metrics_agent.py
+++ b/tests/agents/test_metrics_agent.py
@@ -1,36 +1,46 @@
-# tests/agents/test_metrics_agent.py
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import os
+import asyncio
 import pytest
+import requests
 
 from src.agents.metrics_agent import MetricsAgent
-from opik.evaluation.metrics import AnswerRelevance, Hallucination
+from opik.evaluation.metrics.score_result import ScoreResult
 
-# TODO: OPENAIKEY = BEE_API_KEY?
-# os.environ["OPENAI_API_KEY"] = os.getenv("BEE_API_KEY")
+def is_ollama_up(api_base: str) -> bool:
+    try:
+        return requests.get(f"{api_base}/models", timeout=2).ok
+    except:
+        return False
 
+@pytest.mark.integration
+def test_metrics_agent_with_ollama():
+    api_base = os.getenv("OPENAI_API_BASE", "http://localhost:11434/v1")
+    api_key  = os.getenv("OPENAI_API_KEY", "ollama")
 
-def test_metrics_agent_run_sync(monkeypatch):
-    # never reach OpenAI
-    monkeypatch.setattr(AnswerRelevance, 'score', lambda self, input, output, context: 0.75)
-    monkeypatch.setattr(Hallucination, 'score',   lambda self, input, output, context: 0.10)
+    if not is_ollama_up(api_base):
+        pytest.skip(f"Ollama server not reachable at {api_base}")
 
-    # minimal Agent 
     agent_def = {
         "metadata": {"name": "metrics_agent", "labels": {}},
         "spec": {
-            "framework": "custom",
-            "model": "dummy",
-            "description": "desc",
+            "framework":    "custom",
+            "model":        "qwen3:latest",
+            "description":  "desc",
             "instructions": "instr"
         }
     }
 
     agent = MetricsAgent(agent=agent_def)
-    result = asyncio.run(agent.run("Ping?", "Pong!"))
-    print(result)
-   
-    # assert result["response"]       == "Pong!"
-    # assert result["relevance"]      == pytest.approx(0.75)
-    # assert result["hallucination"]  == pytest.approx(0.10)
+    result = asyncio.run(agent.run("What is the capital of France?", "Paris."))
+
+    assert result["response"] == "Paris."
+    rel = result.get("relevance")
+    assert isinstance(rel, ScoreResult)
+    assert 0.0 <= rel.value <= 1.0
+
+    hall = result.get("hallucination")
+    assert isinstance(hall, ScoreResult)
+    assert 0.0 <= hall.value <= 1.0

--- a/tests/agents/test_metrics_agent.py
+++ b/tests/agents/test_metrics_agent.py
@@ -1,0 +1,36 @@
+# tests/agents/test_metrics_agent.py
+
+import asyncio
+import os
+import pytest
+
+from src.agents.metrics_agent import MetricsAgent
+from opik.evaluation.metrics import AnswerRelevance, Hallucination
+
+# TODO: OPENAIKEY = BEE_API_KEY?
+# os.environ["OPENAI_API_KEY"] = os.getenv("BEE_API_KEY")
+
+
+def test_metrics_agent_run_sync(monkeypatch):
+    # 1) stub out the actual calls so they never reach OpenAI
+    monkeypatch.setattr(AnswerRelevance, 'score', lambda self, input, output, context: 0.75)
+    monkeypatch.setattr(Hallucination, 'score',   lambda self, input, output, context: 0.10)
+
+    # 2) minimal Agent definition your base class needs
+    agent_def = {
+        "metadata": {"name": "metrics_agent", "labels": {}},
+        "spec": {
+            "framework": "custom",
+            "model": "dummy",
+            "description": "desc",
+            "instructions": "instr"
+        }
+    }
+
+    agent = MetricsAgent(agent=agent_def)
+    result = asyncio.run(agent.run("Ping?", "Pong!"))
+
+    # 3) verify that our stubs were used
+    assert result["response"]       == "Pong!"
+    assert result["relevance"]      == pytest.approx(0.75)
+    assert result["hallucination"]  == pytest.approx(0.10)

--- a/tests/agents/test_metrics_agent.py
+++ b/tests/agents/test_metrics_agent.py
@@ -12,11 +12,11 @@ from opik.evaluation.metrics import AnswerRelevance, Hallucination
 
 
 def test_metrics_agent_run_sync(monkeypatch):
-    # 1) stub out the actual calls so they never reach OpenAI
+    # never reach OpenAI
     monkeypatch.setattr(AnswerRelevance, 'score', lambda self, input, output, context: 0.75)
     monkeypatch.setattr(Hallucination, 'score',   lambda self, input, output, context: 0.10)
 
-    # 2) minimal Agent definition your base class needs
+    # minimal Agent 
     agent_def = {
         "metadata": {"name": "metrics_agent", "labels": {}},
         "spec": {
@@ -29,8 +29,8 @@ def test_metrics_agent_run_sync(monkeypatch):
 
     agent = MetricsAgent(agent=agent_def)
     result = asyncio.run(agent.run("Ping?", "Pong!"))
-
-    # 3) verify that our stubs were used
-    assert result["response"]       == "Pong!"
-    assert result["relevance"]      == pytest.approx(0.75)
-    assert result["hallucination"]  == pytest.approx(0.10)
+    print(result)
+   
+    # assert result["response"]       == "Pong!"
+    # assert result["relevance"]      == pytest.approx(0.75)
+    # assert result["hallucination"]  == pytest.approx(0.10)

--- a/tests/yamls/agents/metric_agent.yaml
+++ b/tests/yamls/agents/metric_agent.yaml
@@ -1,0 +1,27 @@
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test1
+  labels:
+    app: test-example
+spec:
+  model: qwen3:latest
+  framework: beeai
+  mode: remote
+  description: this is a test
+  instructions: Concisely answer the question to the best of your ability, and if you are unsure, say "I don't know". 
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: evaluate 
+  labels: 
+    app: test-example
+    custom_agent: metrics_agent
+spec:
+  model: qwen3:latest # NOTE: the model is actually used to determine the LLM call, so must be a valid model
+  framework: custom
+  mode: remote
+  description: testing Opik
+  instructions: evaluates the response using Opik

--- a/tests/yamls/workflows/metric_workflow.yaml
+++ b/tests/yamls/workflows/metric_workflow.yaml
@@ -1,0 +1,22 @@
+apiVersion: maestro/v1
+kind: Workflow
+metadata:
+  name: evaluate workflow
+  labels:
+    app: example
+spec:
+  template:
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: test
+        use-case: test
+    agents:
+        - test1
+        - evaluate
+    prompt: What is the capital of the United States？
+    steps:
+      - name: dummy
+        agent: test1
+      - name: metrics
+        agent: evaluate


### PR DESCRIPTION
For LLM evaluation, user want to rank/determine the best performing responses. OPIK is open source and does it, but makes calls from openai by default. As a workaround i have added support in the src file for this agent to point it at the ollama backend that we are running.