### PR TITLE
demo: mcp setup

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -49,7 +49,7 @@ and navigate to llama3.1 model: <https://ollama.com/library/llama3.1>.
 
 To use a different model, use `ollama pull` and choose from the official models. If using a different model, make sure to define in the agents.yaml file correctly. 
 
-For MCP tools, certain models support tools while others do not. Models that current support tooling that are tested include `llama3.1` and `qwen3`.
+For MCP tools, certain models support tools while others do not. Models that current support tooling that are tested include `llama3.1:8b`, `llama3.3-70b-instruct` and `qwen3:8b`. To note, one of the best performing models we tested `gpt-4o-mini` requires external API credit.
 
 ### Create a Podman machine
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -46,8 +46,10 @@ Verify the installation by running: \
 
 By default, the .env file and api runs on llama version 3.1. Download ollama: <https://ollama.com/>
 and navigate to llama3.1 model: <https://ollama.com/library/llama3.1>.
-If using a different model, make sure to [change the model](https://github.com/i-am-bee/bee-stack?tab=readme-ov-file#custom-models) in the api connection (currently untested).
-Verify Ollama is installed by running command `ollama list` in terminal.
+
+To use a different model, use `ollama pull` and choose from the official models. If using a different model, make sure to define in the agents.yaml file correctly. 
+
+For MCP tools, certain models support tools while others do not. Models that current support tooling that are tested include `llama3.1` and `qwen3`.
 
 ### Create a Podman machine
 

--- a/demos/workflows/mcp-gh-tools.ai/README.md
+++ b/demos/workflows/mcp-gh-tools.ai/README.md
@@ -11,7 +11,8 @@ OPENAI_BASE_URL="http://localhost:11434/v1"
 GITHUB_PERSONAL_ACCESS_TOKEN=token
 ```
 
-Currently, we are running `qwen3` model by default, to change simply adjust in [`agents.yaml`](./agents.yaml). The `llama3.1` model also supports tools.
+To download the github-mcp-server locally, follow the process listed in the `README.md` under ["Example Process using go to binaries"](../openai-mcp.ai/README.md)
+Currently, we are running `qwen3:8b` model by default, to change simply adjust in [`agents.yaml`](./agents.yaml).
 
 ### Streaming
 
@@ -21,6 +22,12 @@ Currently, we are running `qwen3` model by default, to change simply adjust in [
 
 Make sure to enable MCP tools and have exported the github personal access token:
 `/file_location/github-mcp-server stdio --toolsets all`
+
+To enable logging:
+
+```bash
+github-mcp-server stdio --enable-command-logging --log-file /var/log/github-mcp-server.log
+```
 
 To run:
 `maestro run demos/workflows/mcp-gh-tools.ai/agents.yaml demos/workflows/mcp-gh-tools.ai/workflow.yaml`

--- a/demos/workflows/mcp-gh-tools.ai/README.md
+++ b/demos/workflows/mcp-gh-tools.ai/README.md
@@ -1,0 +1,26 @@
+# MCP Walkthrough
+
+This demo shows how to use Maestro agents and connect to/use MCP tools, an extension of listing the avaiable tools as seen in the original [openai-mcp demo](../openai-mcp.ai/README.md).
+
+## Required Exports
+
+```bash
+MAESTRO_MCP_ENDPOINTS="/Users/gliu/Desktop/work/github-mcp-server/cmd/github-mcp-server/github-mcp-server"
+OPENAI_API_KEY=ollama
+OPENAI_BASE_URL="http://localhost:11434/v1" 
+GITHUB_PERSONAL_ACCESS_TOKEN=token
+```
+
+Currently, we are running `qwen3` model by default, to change simply adjust in [`agents.yaml`](./agents.yaml). The `llama3.1` model also supports tools.
+
+### Streaming
+
+`export MAESTRO_OPENAI_STREAMING=true`
+
+### Running the Workflow
+
+Make sure to enable MCP tools and have exported the github personal access token:
+`/file_location/github-mcp-server stdio --toolsets all`
+
+To run:
+`maestro run demos/workflows/mcp-gh-tools.ai/agents.yaml demos/workflows/mcp-gh-tools.ai/workflow.yaml`

--- a/demos/workflows/mcp-gh-tools.ai/agents.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/agents.yaml
@@ -8,15 +8,23 @@ spec:
   model: qwen3
   description: me info
   instructions: |
-    You are an agent whose job is to answer “Who am I?” on GitHub using the get_me() tool in the github_mcp.
-    Note the tool is not defined in our agent, but rather in the Github MCP so you must call it there.
-    `GITHUB_PERSONAL_ACCESS_TOKEN` is already provided in the environment to authenticate with GitHub.
+    You are an agent whose sole GitHub integrations live in the **GitHub MCP**.  
+    **Do NOT** use or define any local “get_me” or “search_repositories” functions—only invoke the MCP’s tools, they are not local functions!
 
-    Important rules:
+    Steps to complete:
 
-      1. Do *NOT* use any tools in the agent itself. You must use the MCP tool to call the GitHub API.
-      2. **Plan & reflect** before and after *every* function call.  
-      3. Only terminate once you’ve collected and summarized name, username, bio, email, orgs, and public-repo stats.
+      1. **Call** `get_me()` (from GitHub MCP) using the provided
+         `GITHUB_PERSONAL_ACCESS_TOKEN` to fetch your profile.
+      2. **Extract** your `login` field from that response.
+      3. **Call** `search_repositories()` (from GitHub MCP) with:
+         ```json
+         { "query": "user:<login>" }
+         ```
+         to retrieve all repos you own.
+      4. **Plan & reflect** before and after each MCP call.
+      5. **Only terminate** once you output:
+         - **Name** and **login**
+         - A **bullet list** of each repo name with its URL
 
   framework: openai
   mode: local

--- a/demos/workflows/mcp-gh-tools.ai/agents.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/agents.yaml
@@ -1,32 +1,22 @@
-# apiVersion: maestro/v1alpha1
-# kind: Agent
-# metadata:
-#   name: search_repos
-#   labels:
-#     app: testapp_mcp_ollama
-# spec:
-#   model: llama3.1
-#   framework: openai
-#   mode: local
-#   description: test
-#   instructions: You are a helpful agent. Respond to the users question, making use of any required tools inside of Github-MCP specifically.
-
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
-  name: getme
+  name: test
   labels:
     app: cbom.ai
 spec:
   model: qwen3
   description: me info
   instructions: |
-    Tell me about me, the authenticated user on github
-    Keep the output fairly concise
-    Remember these important rules:
-      - You are an agent - please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
-      - If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
-      - You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
-      - you should check the name of the tool you are going to use carefully against what is available
+    You are an agent whose job is to answer “Who am I?” on GitHub using the get_me() tool in the github_mcp.
+    Note the tool is not defined in our agent, but rather in the Github MCP so you must call it there.
+    `GITHUB_PERSONAL_ACCESS_TOKEN` is already provided in the environment to authenticate with GitHub.
+
+    Important rules:
+
+      1. Do *NOT* use any tools in the agent itself. You must use the MCP tool to call the GitHub API.
+      2. **Plan & reflect** before and after *every* function call.  
+      3. Only terminate once you’ve collected and summarized name, username, bio, email, orgs, and public-repo stats.
+
   framework: openai
   mode: local

--- a/demos/workflows/mcp-gh-tools.ai/agents.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/agents.yaml
@@ -9,27 +9,20 @@ spec:
   description: me info
   instructions: |
     You are an agent whose sole GitHub integrations live in the **GitHub MCP**.  
-    **Do NOT** use or define any local “get_me” or “search_repositories” functions—only invoke the MCP’s tools, they are not local functions!
+    **Do NOT** use or define any local “get_me” functions—only invoke the MCP’s tools, they are not local functions!
 
     Steps to complete:
 
       1. **Call** `get_me()` (from GitHub MCP) using the provided
-         `GITHUB_PERSONAL_ACCESS_TOKEN` to fetch your profile.
+         `GITHUB_PERSONAL_ACCESS_TOKEN` to fetch my profile.
       2. Summarize the response to answer:
          - **Name** and **login**
          - **Bio** (if available)
          - **Location** (if available)
          - **Email** (if available)
          - **Avatar URL**
-      3. **Call** `search_repositories()` (from GitHub MCP) with:
-         ```json
-         { "query": "user:<login>" }
-         ```
-         to retrieve all repos you own, and then report them back.
       4. **Plan & reflect** before and after each MCP call.
-      5. **Only terminate** once you output:
-         - The summary of my profile
-         - A **bullet list** of each repo name with its URL
+      5. **Only terminate** after you create a concise summary of my profile, highlighting the most important features.
 
   framework: openai
   mode: local

--- a/demos/workflows/mcp-gh-tools.ai/agents.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/agents.yaml
@@ -1,0 +1,32 @@
+# apiVersion: maestro/v1alpha1
+# kind: Agent
+# metadata:
+#   name: search_repos
+#   labels:
+#     app: testapp_mcp_ollama
+# spec:
+#   model: llama3.1
+#   framework: openai
+#   mode: local
+#   description: test
+#   instructions: You are a helpful agent. Respond to the users question, making use of any required tools inside of Github-MCP specifically.
+
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: getme
+  labels:
+    app: cbom.ai
+spec:
+  model: qwen3
+  description: me info
+  instructions: |
+    Tell me about me, the authenticated user on github
+    Keep the output fairly concise
+    Remember these important rules:
+      - You are an agent - please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
+      - If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+      - You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
+      - you should check the name of the tool you are going to use carefully against what is available
+  framework: openai
+  mode: local

--- a/demos/workflows/mcp-gh-tools.ai/agents.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/agents.yaml
@@ -15,15 +15,20 @@ spec:
 
       1. **Call** `get_me()` (from GitHub MCP) using the provided
          `GITHUB_PERSONAL_ACCESS_TOKEN` to fetch your profile.
-      2. **Extract** your `login` field from that response.
+      2. Summarize the response to answer:
+         - **Name** and **login**
+         - **Bio** (if available)
+         - **Location** (if available)
+         - **Email** (if available)
+         - **Avatar URL**
       3. **Call** `search_repositories()` (from GitHub MCP) with:
          ```json
          { "query": "user:<login>" }
          ```
-         to retrieve all repos you own.
+         to retrieve all repos you own, and then report them back.
       4. **Plan & reflect** before and after each MCP call.
       5. **Only terminate** once you output:
-         - **Name** and **login**
+         - The summary of my profile
          - A **bullet list** of each repo name with its URL
 
   framework: openai

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -14,8 +14,19 @@ spec:
     prompt: |
       I want to learn about the authenticated GitHub user (myself).
 
-      1. Use the get_me() tool in Github MCP to call to get my user profile.  
-      2. Search for all repositories I own using the search_repositories() tool in Github MCP.
+      1. Use the get_me() tool in Github MCP to call to get my user profile, and then output a summary of my profile.  
+         - Include my name, login, bio, location, email, and avatar URL.  
+         - If any of these fields are not available, just skip them.  
+         - Use the following format:
+           ```
+           - Name: <name>
+           - Login: <login>
+           - Bio: <bio>
+           - Location: <location>
+           - Email: <email>
+           - Avatar URL: <avatar_url>
+           ```  
+      2. Search for all repositories I own using the search_repositories() tool in Github MCP, and then report them back.
 
       **Rules:**  
       - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -13,19 +13,7 @@ spec:
       - test
     prompt: |
       I want to learn about the authenticated GitHub user (myself).
-
-      1. Use the get_me() tool in Github MCP to call to get my user profile, and then output a summary of my profile.  
-         - Include my name, login, bio, location, email, and avatar URL.  
-         - If any of these fields are not available, just skip them.  
-         - Use the following format:
-           ```
-           - Name: <name>
-           - Login: <login>
-           - Bio: <bio>
-           - Location: <location>
-           - Email: <email>
-           - Avatar URL: <avatar_url>
-           ```  
+      1. Use the get_me() tool in Github MCP to call to get my user profile, and then output a summary of my profile.
       **Rules:**  
       - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  
     steps:

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -26,8 +26,6 @@ spec:
            - Email: <email>
            - Avatar URL: <avatar_url>
            ```  
-      2. Search for all repositories I own using the search_repositories() tool in Github MCP, and then report them back.
-
       **Rules:**  
       - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  
     steps:

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -1,0 +1,34 @@
+apiVersion: maestro/v1alpha1
+kind: Workflow
+metadata:
+  name: openai_test_mcp_ollama
+  labels:
+    app: testapp_mcp_ollama
+spec:
+  template:
+    metadata:
+      labels:
+        app: testapp_mcp_ollama
+    agents:
+      - test_mcp_ollama
+      - search_repos
+    prompt: |
+      I want to learn about the authenticated GitHub user (myself).
+      **Plan & reflect:**  
+      1. Think through which MCP tool you need to call to get my user profile.  
+      2. Use up to 3 relevant github MCP tools to get the information.
+      3. After you receive the response, reflect on what fields are most important (login, name, email, company, location, etc.).  
+      4. Summarize those fields concisely for me.  
+
+      **Rules:**  
+      - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  
+      - Show your planning as bullet points before your function call.  
+      - Then issue the JSON function call object
+    # prompt: |
+    #   Please call the `github.search_repositories` function/tool that is found inside Github-MCP to list all repositories
+    #   the authenticated user has access to. Use the query string `user:<YOUR_LOGIN>`.
+    #   _Respond with only the JSON function_call object_, no extra text.
+    steps:
+    - name: step1
+      agent: getme
+      # agent: search_repos

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -14,9 +14,8 @@ spec:
     prompt: |
       I want to learn about the authenticated GitHub user (myself).
 
-      1. Use the get me tool in Github MCP to call to get my user profile.  
-      2. After you receive the response, reflect on what fields are most important (login, name, email, company, location, etc.).  
-      3. Summarize those fields concisely for me.  
+      1. Use the get_me() tool in Github MCP to call to get my user profile.  
+      2. Search for all repositories I own using the search_repositories() tool in Github MCP.
 
       **Rules:**  
       - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  

--- a/demos/workflows/mcp-gh-tools.ai/workflow.yaml
+++ b/demos/workflows/mcp-gh-tools.ai/workflow.yaml
@@ -10,25 +10,16 @@ spec:
       labels:
         app: testapp_mcp_ollama
     agents:
-      - test_mcp_ollama
-      - search_repos
+      - test
     prompt: |
       I want to learn about the authenticated GitHub user (myself).
-      **Plan & reflect:**  
-      1. Think through which MCP tool you need to call to get my user profile.  
-      2. Use up to 3 relevant github MCP tools to get the information.
-      3. After you receive the response, reflect on what fields are most important (login, name, email, company, location, etc.).  
-      4. Summarize those fields concisely for me.  
+
+      1. Use the get me tool in Github MCP to call to get my user profile.  
+      2. After you receive the response, reflect on what fields are most important (login, name, email, company, location, etc.).  
+      3. Summarize those fields concisely for me.  
 
       **Rules:**  
       - Only terminate your turn once your summary fully answers “Who am I?” on GitHub.  
-      - Show your planning as bullet points before your function call.  
-      - Then issue the JSON function call object
-    # prompt: |
-    #   Please call the `github.search_repositories` function/tool that is found inside Github-MCP to list all repositories
-    #   the authenticated user has access to. Use the query string `user:<YOUR_LOGIN>`.
-    #   _Respond with only the JSON function_call object_, no extra text.
     steps:
     - name: step1
-      agent: getme
-      # agent: search_repos
+      agent: test

--- a/demos/workflows/openai-mcp.ai/README.md
+++ b/demos/workflows/openai-mcp.ai/README.md
@@ -12,13 +12,12 @@ what the tools do).
 
 The automated test makes use of [GitHub mcp server](https://github.com/github/github-mcp-server).
 
-Download the latest release, and use the path to the `github-mcp-server` in the environment settings below.
+### Example Process using go to build binaries
+  1) Clone the MCP Server Repo and go into github-mcp-server directory
+  2) Build the binary located inside `cmd/github-mcp-server` using `go build -o github-mcp-server`
+  3) Point Maestro at the server: `export MAESTRO_MCP_ENDPOINTS="/full/path/to/github-mcp-server stdio"`
 
-The `GITHUB_PERSONAL_ACCESS_TOKEN` is needed for derivations of this demo which may do real github work. For the purpose of automated testing this is set to a dummy value.
-
-All commands below are relative to the `maestro` subdirectory of the repository.
-
-## Standalone execution
+### Relative exports needed for standalone execution
 
 ```shell
 export GITHUB_PERSONAL_ACCESS_TOKEN=<github-token>
@@ -26,6 +25,16 @@ export OPENAI_API_KEY=ollama
 export OPENAI_BASE_URL="http://localhost:11434/v1" 
 export MAESTRO_MCP_ENDPOINTS="/Users/jonesn/bin/github-mcp-server stdio"
 maestro run demos/workflows/openai-mcp.ai/agents.yaml demos/workflows/openai-mcp.ai/workflow.yaml
+```
+
+The `GITHUB_PERSONAL_ACCESS_TOKEN` is needed for derivations of this demo which may do real github work. For the purpose of automated testing this is set to a dummy value.
+
+All commands below are relative to the `maestro` subdirectory of the repository.
+
+Successful connection should output:
+```shell
+🔓 INFO [openai_test_mcp_ollama - MCP Setup]: MCP Server (Stdio) connected: openai_test_mcp_ollama_MCP_Server_1_Stdio (/github-mcp-server-file-path stdio)
+🔓 INFO [openai_test_mcp_ollama - MCP Setup]: Successfully connected to 1 MCP server(s).
 ```
 
 ## Automated execution

--- a/demos/workflows/openai-mcp.ai/agents.yaml
+++ b/demos/workflows/openai-mcp.ai/agents.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: testapp_mcp_ollama
 spec:
-  model: "granite3.3:2b"
+  model: llama3.1
   description: test
   instructions: You are a helpful agent. Respond to the users question, making use of any required tools
   framework: openai

--- a/demos/workflows/openai-mcp.ai/workflow.yaml
+++ b/demos/workflows/openai-mcp.ai/workflow.yaml
@@ -12,7 +12,7 @@ spec:
     agents:
       - openai_test_ollama
     prompt: | 
-      What tools do you have access to? Include all kinds of different types of tools? Print
+      What tools do you have access to in Github-MCP? Include all kinds of different types of tools? Print
       out as much information about them as you can, but you MUST also include the text "Tools found [nnn]: 
       followed by a list of exact tool names only, all on a single line. Replace nnn with the number of tools found.
     steps:


### PR DESCRIPTION
I’m trying to reproduce the “Who am I?” flow in a demo with calling the Github MCP tool, but I keep hitting “tools not found” errors. I realize I may not fully understand how Maestro wires up function calls to the MCP server, so hope you can take a look at my workflow configuration/prompts to see my flaw in logic.

What I’ve done so far:
Pointed MAESTRO_MCP_ENDPOINTS at my local github-mcp-server stdio.
Switched my agent to mode: local so it can spawn the MCP server.
In my prompt, I’ve asked the model to "GH MCP tools in order to fetch relevant information”

Where I’m getting stuck:
LLM will end up choosing some functions/tools to use, but doesn't seem like they are able to be exectued

I’m not sure whether I need a tools: declaration in agents.yaml, or a special function_call setting, or editing the prompts to let the LLM to all this itself?

I’d like to understand exactly how/what the prompt should do, is it to trigger a raw JSON function call, rather than returning a code snippet or an error? Or something else that you did to get the correct output?

fixes #482 
