### PR TITLE
enhance step/inputs

### DIFF
--- a/src/workflow.py
+++ b/src/workflow.py
@@ -137,6 +137,8 @@ class Workflow:
                     src = inp["from"]
                     if src == "prompt":
                         args.append(initial_prompt)
+                    elif "instructions:" in src:
+                        args.append(step_defs[src.split(":")[-1]]["agent"].agent_instr)
                     elif src in step_results:
                         args.append(step_results[src])
                     else:

--- a/tests/workflow/test_inputs.py
+++ b/tests/workflow/test_inputs.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright © 2025 IBM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os, yaml
+import pytest
+from unittest import TestCase
+from src.workflow import Workflow
+
+import asyncio
+
+def parse_yaml(file_path):
+    with open(file_path, "r") as file:
+        yaml_data = list(yaml.safe_load_all(file))
+    return yaml_data
+
+# `inputs` tests
+class TestInputs(TestCase):
+    def setUp(self):
+        self.agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/agents/dry_run_inputs_agent.yaml"))
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/dry_run_inputs_workflow.yaml"))
+        try:
+            self.workflow = Workflow(self.agents_yaml, self.workflow_yaml[0])
+        except Exception as excep:
+            raise RuntimeError("Unable to create agents") from excep
+
+    def tearDown(self):
+        self.workflow = None
+
+    def test_inputs(self):
+        response = asyncio.run(self.workflow.run())
+        assert "this is a test 1." in response["final_prompt"]
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/yamls/agents/dry_run_inputs_agent.yaml
+++ b/tests/yamls/agents/dry_run_inputs_agent.yaml
@@ -1,0 +1,53 @@
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test1
+  labels:
+    app: test-example
+spec:
+  model: meta-llama/llama-3-1-70b-instruct
+  framework: beeai
+  mode: remote
+  description: this is a test
+  tools:
+    - code_interpreter
+    - test
+  instructions: print("this is a test 1.")
+
+---
+
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test2
+  labels:
+    app: test-example
+spec:
+  model: meta-llama/llama-3-1-70b-instruct
+  framework: beeai
+  mode: remote
+  description: this is a test
+  tools:
+    - code_interpreter
+    - test
+  instructions: |
+    print(f"prompt is {input}")
+    input = f"answer from test2: I got {input}!!"
+
+---
+
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test3
+  labels:
+    app: test-example
+spec:
+  model: meta-llama/llama-3-1-70b-instruct
+  framework: beeai
+  mode: remote
+  description: this is a test
+  tools:
+    - code_interpreter
+    - test
+  instructions: print(f"this is input for this step {input}.")

--- a/tests/yamls/workflows/dry_run_inputs_workflow.yaml
+++ b/tests/yamls/workflows/dry_run_inputs_workflow.yaml
@@ -1,0 +1,27 @@
+apiVersion: maestro/v1
+kind: Workflow
+metadata:
+  name: simple workflow
+  labels:
+    app: example2
+spec:
+  template:
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: example
+        use-case: test
+    agents:
+        - test1
+        - test2
+        - test3
+    prompt: This is a test input
+    steps:
+      - name: step1
+        agent: test1
+      - name: step2
+        inputs:
+        - from: instructions:step1
+        agent: test2
+      - name: step3
+        agent: test3

--- a/tests/yamls/workflows/dry_run_inputs_workflow.yaml
+++ b/tests/yamls/workflows/dry_run_inputs_workflow.yaml
@@ -19,9 +19,9 @@ spec:
     steps:
       - name: step1
         agent: test1
-      - name: step2
+      - name: step2                   
         inputs:
-        - from: instructions:step1
+        - from: instructions:step1    # For step2, pass in the instructions: field from the agent used in step1.
         agent: test2
       - name: step3
         agent: test3


### PR DESCRIPTION
fix #500 

This PR enables a new input type: pulling an agent’s instructions field from a previous step (e.g., for reflection, reuse, meta-programming, etc.).

