### PR TITLE
demo: change fetch tool from llm to codeagent

### DIFF
--- a/demos/workflows/cbom.ai/README.md
+++ b/demos/workflows/cbom.ai/README.md
@@ -95,12 +95,17 @@ participant identify post_quantum
 participant component creator
 participant BOM Assembler
 participant selector agent
+participant score
+participant fixer_agent
+participant patcher_agent
 git fetcher->>selector agent: step1
 selector agent->>raw gh reader: step2
 raw gh reader->>identify post_quantum: step3
 identify post_quantum->>component creator: step4
 component creator->>BOM Assembler: step5
-BOM Assembler->>BOM Assembler: step6
+BOM Assembler->>fixer_agent: step6
+fixer_agent->>patcher_agent: code_step
+patcher_agent->>patcher_agent: patch_pull_step
 ```
 <!-- MERMAID_END -->
 

--- a/demos/workflows/cbom.ai/agents.yaml
+++ b/demos/workflows/cbom.ai/agents.yaml
@@ -1,58 +1,31 @@
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
-  name: git fetcher
+  name: gh fetch
   labels:
     app: cbom.ai
 spec:
-  model: qwen3:latest
-  description: |
-    output the java files given a repository
-  instructions: |
-    You are the **Java Fetcher** agent.  
-    **IMPORTANT**: After you invoke the `java-fetcher` tool, you MUST **directly return** its output — exactly character-for-character—and nothing else.  
-    Do **not**:
-      - Reformat or prettify the list  
-      - Edit, Sort, filter, dedupe, or correct paths  
-      - Append any commentary  
-    **Steps:**  
-      1. Invoke the tool:  
-        ```Python
-        java-fetcher(owner="given owner input", repo="given repo input")
-        ```  
-      3. Receive the tool’s response, an array of URLs: ['url1', 'url2', 'url3', etc ...]
-      4. **Immediately** print/output that array exactly as-is. *NOTHING ELSE AND NO EDITING*
-  mode: remote
-  tools:
-    - java-fetcher
+  framework: code
+  mode: local
+  description: Fetch .java files via GitHub API
   code: |
     import requests
+    import sys
 
-    def get_java_file_urls(owner: str, repo: str, branch: str = "main") -> list[str]:
-        """
-        Retrieve raw.githubusercontent.com URLs for all .java files in a GitHub repo
-        by using the Git Trees API with recursion.
+    owner, repo = "Mastercard", "client-encryption-java"
+    branch = "main"
 
-        :param owner: GitHub org/user name (e.g., "Mastercard")
-        :param repo: Repository name (e.g., "client-encryption-java")
-        :param branch: Branch name (default: "main")
-        :param token: GitHub Personal Access Token (optional for private repos or rate limiting)
-        :return: List of raw.githubusercontent.com URLs for each .java file
-        """
-        
-        tree_api_url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
-    
-        response = requests.get(tree_api_url)
-        response.raise_for_status()
-        tree_data = response.json().get("tree", [])
-        
-        java_urls = []
-        for entry in tree_data:
-            if entry.get("type") == "blob" and entry.get("path", "").endswith(".java"):
-                raw_url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{entry['path']}"
-                java_urls.append(raw_url)
-        
-        return java_urls
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
+    response = requests.get(url)
+    response.raise_for_status()
+    tree = response.json().get("tree", [])
+
+    java_urls = [
+        f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{item['path']}"
+        for item in tree if item["path"].endswith(".java")
+    ]
+
+    output['urls'] = java_urls
 
 ---
 apiVersion: maestro/v1alpha1

--- a/demos/workflows/cbom.ai/workflow.yaml
+++ b/demos/workflows/cbom.ai/workflow.yaml
@@ -41,7 +41,7 @@ spec:
         - from: "Given a raw github link, output its raw file directly."
         - from: step3
       context:
-        - "A correct output should just be the raw version of a java file."
+        - "The current output should be the following: https://raw.githubusercontent.com/Mastercard/client-encryption-java/main/src/main/java/com/mastercard/developer/encryption/EncryptionConfig.java"
     - name: step4
       agent: identify post-quantum
     - name: step5

--- a/demos/workflows/cbom.ai/workflow.yaml
+++ b/demos/workflows/cbom.ai/workflow.yaml
@@ -10,7 +10,7 @@ spec:
       labels:
         app: cbom.ai
     agents:
-      - git fetcher
+      - gh fetch
       - raw gh reader
       - identify post-quantum
       - component creator
@@ -23,7 +23,7 @@ spec:
       Use the git fetcher tool to get all the java files from the github repo where the owner is "Mastercard" and the repo is "client-encryption-java", and directly output its result. The output should be *ONLY* a list of URLs, and nothing else.
     steps:
     - name: step1
-      agent: git fetcher
+      agent: gh fetch
     - name: step2
       agent: selector agent
     - name: step2_score

--- a/demos/workflows/cbom.ai/workflowrun.yaml
+++ b/demos/workflows/cbom.ai/workflowrun.yaml
@@ -7,7 +7,6 @@ metadata:
   name: cbom-ai
 spec:
   agents:
-  - git-fetcher
   - raw-gh-reader
   - identify-post-quantum
   - component-creator


### PR DESCRIPTION
fixes #511, reduces time from 5 min to <1 sec for the initial agent.

@akihikokuroda am i correct in assuming since this agent is now a code agent, it should not be included in the `workflowrun.yaml` file? Since the other code agents are also not included?