### PR TITLE
fix broken agent command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ uv pip install -r requirements-extra.txt
 uv run maestro run <workflow_path>
 ```
 
-2. Run an agent:
+2. Create an agent:
 ```bash
-uv run maestro run <agent_path>
+uv run maestro create <agent_path>
 ```
 
 3. Validate a workflow or agent:

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache license- see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
`maestro run <agent_path>` is an invalid command
also we're using apache not mit license