### PR TITLE
test: switch to using ruff for format and lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.12.0
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+    # Run the formatter.
+    - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,11 @@ source .venv/bin/activate  # On Unix/macOS
 uv pip install -e .
 ```
 
+4. (optional) Enable pre-commit
+```bash
+uv run pre-commit install
+```
+
 ## Development Workflow
 
 1. Create a new branch for your feature or bugfix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,17 +10,17 @@ git clone https://github.com/AI4quantum/maestro.git
 cd maestro
 ```
 
-2. Install dependencies:
-```bash
-uv pip install -e .
-```
-
-3. Activate the virtual environment:
+2. Activate the virtual environment:
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # On Unix/macOS
 # or
 .venv\Scripts\activate  # On Windows
+```
+
+3. Install dependencies:
+```bash
+uv pip install -e .
 ```
 
 ## Development Workflow
@@ -43,7 +43,7 @@ git push origin feature/your-feature-name
 
 ## Code Style
 
-We use [black](https://github.com/psf/black) for code formatting. To ensure your code meets our style guidelines:
+We use [ruff](https://docs.astral.sh/ruff/) for code formatting and linting. To ensure your code meets our style guidelines:
 
 1. Install development dependencies:
 ```bash
@@ -52,7 +52,12 @@ uv pip install -e .
 
 2. Run the formatter:
 ```bash
-uv run black
+uv run ruff format
+```
+
+3. Run the linter:
+```bash
+uv run ruff check --fix
 ```
 
 ## Commit Messages
@@ -86,9 +91,10 @@ git commit -m "feat(agent): add new agent type"
 
 1. Ensure all dependencies are installed (`uv pip install -e .`).
 2. Run the test suite (`uv run pytest`).
-3. Run the linter (`uv run black`).
-4. Update documentation if necessary.
-5. Create a pull request with a clear description of the changes.
+3. Run the formatter (`uv run ruff format`).
+4. Run the linter (`uv run ruff check --fix`).
+5. Update documentation if necessary.
+6. Create a pull request with a clear description of the changes.
 
 ## Additional Resources
 
@@ -106,7 +112,7 @@ If you are new to Maestro contributing, we recommend you do the following before
 Maestro uses the following tools to meet code quality standards and ensure a unified code style across the codebase:
 
 We use the following libs to check the Python code: 
-- [Black](https://black.readthedocs.io/) - Code Formatter
+- [ruff](https://docs.astral.sh/ruff/) - Code Formatter and Linter
 
 ## Issues and pull requests
 
@@ -168,12 +174,11 @@ feat(agent): add new OpenAI agent type
 Ref: #15
 ```
 
-6. **Run Linters/Formatters:** Ensure your changes meet code quality standards:
-
-     - lint: use the next command to run Pylint:
+6. **Run Linter/Formatter:** Ensure your changes meet code quality standards:
 
 ```bash
-uv run pylint src/
+uv run ruff format
+uv run ruff check --fix
 ```
   
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ uv pip install -e .
 uv run pytest
 ```
 
-4. Run formatter:
+4. Run the formatter:
 ```bash
-uv run black
+uv run ruff format
+```
+
+5. Run the linter:
+```bash
+uv run ruff check --fix
 ```
 
 ## Contributing

--- a/demos/CONTRIBUTING.md
+++ b/demos/CONTRIBUTING.md
@@ -23,6 +23,11 @@ source .venv/bin/activate  # On Unix/macOS
 uv pip install -e .
 ```
 
+4. (optional) Enable pre-commit
+```bash
+uv run pre-commit install
+```
+
 ## Development Workflow
 
 1. Create a new branch for your feature or bugfix:

--- a/demos/CONTRIBUTING.md
+++ b/demos/CONTRIBUTING.md
@@ -10,17 +10,17 @@ git clone https://github.com/AI4quantum/maestro.git
 cd maestro
 ```
 
-2. Install dependencies:
-```bash
-uv pip install -e .
-```
-
-3. Activate the virtual environment:
+2. Activate the virtual environment:
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # On Unix/macOS
 # or
 .venv\Scripts\activate  # On Windows
+```
+
+3. Install dependencies:
+```bash
+uv pip install -e .
 ```
 
 ## Development Workflow
@@ -43,16 +43,21 @@ git push origin feature/your-feature-name
 
 ## Code Style
 
-We use [black](https://github.com/psf/black) for code formatting and [pylint](https://pylint.pycqa.org/) for linting. To ensure your code meets our style guidelines:
+We use [ruff](https://docs.astral.sh/ruff/) for code formatting and linting. To ensure your code meets our style guidelines:
 
 1. Install development dependencies:
 ```bash
-uv pip install -e ".[dev]"
+uv pip install -e .
 ```
 
-2. Run the linter:
+2. Run the formatter:
 ```bash
-uv run pylint src/
+uv run ruff format
+```
+
+3. Run the linter:
+```bash
+uv run ruff check --fix
 ```
 
 ## Commit Messages
@@ -86,9 +91,10 @@ git commit -m "feat(agent): add new agent type"
 
 1. Ensure all dependencies are installed (`uv pip install -e .`).
 2. Run the test suite (`uv run pytest`).
-3. Run the linter (`uv run pylint src/`).
-4. Update documentation if necessary.
-5. Create a pull request with a clear description of the changes.
+3. Run the formatter (`uv run ruff format`).
+4. Run the linter (`uv run ruff check --fix`).
+5. Update documentation if necessary.
+6. Create a pull request with a clear description of the changes.
 
 ## Additional Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dev = [
     "python-dotenv>=1.1.0",
     "ruff>=0.12.0",
     "pytest>=8.3.4",
-    "pytest-mock>=3.14.0"
+    "pytest-mock>=3.14.0",
+    "pre-commit>=4.2.0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ crewai = [
 [dependency-groups]
 dev = [
     "python-dotenv>=1.1.0",
-    "black>=24.10.0",
+    "ruff>=0.12.0",
     "pytest>=8.3.4",
     "pytest-mock>=3.14.0"
 ]

--- a/tools/scripts.py
+++ b/tools/scripts.py
@@ -8,7 +8,7 @@ import re
 
 def lint():
     try:
-        subprocess.run(["black", "."], check=True)
+        subprocess.run(["ruff", "format", "."], check=True)
         subprocess.run(["ruff", "check", "."], check=True)
     except subprocess.CalledProcessError:
         sys.exit(1)


### PR DESCRIPTION
This adds support for code formatting and littering using ruff and included the relevant doc updates.

It also includes a pre-commit config that is not enabled by default.

> [!IMPORTANT]  
> This PR does not enforce any formatting or linting, it only adds the dev dependencies, configs, and documentation

I have also done an initial run of the formatter and linter and committed it in a separate branch: https://github.com/AI4quantum/maestro/commit/99ebdae410ea418c7a98dd1bb56420d6df3a9bd1

If desired I can include that commit in this PR, otherwise it will be opened as a followup draft PR for later