### PR TITLE
fix: allow cors for maestro serve

### DIFF
--- a/src/maestro/agents/openai_agent.py
+++ b/src/maestro/agents/openai_agent.py
@@ -26,6 +26,9 @@ from agents.extensions.models.litellm_model import LitellmModel
 from maestro.agents.agent import Agent as MaestroAgent
 from maestro.agents.openai_mcp import setup_mcp_servers, MCPServerInstance
 
+from dotenv import load_dotenv
+
+load_dotenv()
 
 SUPPORTED_TOOL_NAME: Final[str] = "web_search"
 TOOL_REQUIRES_RESPONSES_API: Final[bool] = True

--- a/src/maestro/cli/fastapi_serve.py
+++ b/src/maestro/cli/fastapi_serve.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -57,6 +58,13 @@ class FastAPIServer:
             title="Maestro Agent Server",
             description="HTTP API for serving Maestro agents",
             version="1.0.0",
+        )
+        self.app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
         )
         self._setup_routes()
         self._load_agents()

--- a/src/maestro/cli/fastapi_serve.py
+++ b/src/maestro/cli/fastapi_serve.py
@@ -4,6 +4,7 @@
 """FastAPI server module for serving Maestro agents via HTTP endpoints."""
 
 import json
+import os
 from datetime import datetime
 from typing import Optional
 
@@ -16,6 +17,10 @@ from pydantic import BaseModel
 from maestro.workflow import create_agents, Workflow
 from maestro.agents.agent import restore_agent
 from maestro.cli.common import parse_yaml, Console
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 class ChatRequest(BaseModel):
@@ -59,12 +64,13 @@ class FastAPIServer:
             description="HTTP API for serving Maestro agents",
             version="1.0.0",
         )
+        allowed_origins = [
+            x.strip() for x in os.getenv("CORS_ALLOW_ORIGINS", "").split(",")
+        ]
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_origins=allowed_origins,
+            allow_methods=["GET", "POST"],
         )
         self._setup_routes()
         self._load_agents()
@@ -226,7 +232,7 @@ class FastAPIWorkflowServer:
 
         Args:
             agents_file: Path to the agents YAML file
-            workfloe_file: Path to the workflow YAML file
+            workflow_file: Path to the workflow YAML file
         """
         self.agents_file = agents_file
         self.workflow_file = workflow_file
@@ -236,12 +242,13 @@ class FastAPIWorkflowServer:
             description="HTTP API for serving Maestro workflow",
             version="1.0.0",
         )
+        allowed_origins = [
+            x.strip() for x in os.getenv("CORS_ALLOW_ORIGINS", "").split(",")
+        ]
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_origins=allowed_origins,
+            allow_methods=["GET", "POST"],
         )
         self._setup_routes()
         self._load_workflow()


### PR DESCRIPTION
Updates `maestro serve` to support a configurable env var `CORS_ALLOW_ORIGINS` for CORS. This comma-delimitated var is read from the env at the startup of maestro serve, and by default is empty