### PR TITLE
chore: switch to `uv sync` for dev install

### DIFF
--- a/.github/workflows/maestro_check-mermaid.yaml
+++ b/.github/workflows/maestro_check-mermaid.yaml
@@ -21,7 +21,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .
+        uv sync
     - name: Check mermaid
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_check-schemas.yaml
+++ b/.github/workflows/maestro_check-schemas.yaml
@@ -21,7 +21,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .
+        uv sync
     - name: Check schemas
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_demo-tests.yaml
+++ b/.github/workflows/maestro_demo-tests.yaml
@@ -21,7 +21,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .
+        uv sync
     - name: Run demo tests
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_deploy-tests.yaml
+++ b/.github/workflows/maestro_deploy-tests.yaml
@@ -21,7 +21,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .[crewai]
+        uv sync
     - name: Run deploy tests
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_deploy-tests.yaml
+++ b/.github/workflows/maestro_deploy-tests.yaml
@@ -21,7 +21,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --all-extras
     - name: Run deploy tests
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_operator-build.yaml
+++ b/.github/workflows/maestro_operator-build.yaml
@@ -23,7 +23,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .
+        uv sync
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       

--- a/.github/workflows/maestro_operator-test.yaml
+++ b/.github/workflows/maestro_operator-test.yaml
@@ -48,7 +48,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --all-extras
     - name: Deploy test agents, workflow, configmap and workflowrun
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_operator-test.yaml
+++ b/.github/workflows/maestro_operator-test.yaml
@@ -48,7 +48,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .[crewai]
+        uv sync
     - name: Deploy test agents, workflow, configmap and workflowrun
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -20,7 +20,7 @@ jobs:
           activate-environment: true
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --all-extras
       - name: Run tests
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)/src
@@ -43,7 +43,7 @@ jobs:
           activate-environment: True
       - name: Install dependencies
         run: |
-          uv sync
+          uv pip install requests
       - name: Get release name
         id: get_name
         run: |

--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -20,7 +20,7 @@ jobs:
           activate-environment: true
       - name: Install dependencies
         run: |
-          uv pip install -e .[crewai]
+          uv sync
       - name: Run tests
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)/src
@@ -43,7 +43,7 @@ jobs:
           activate-environment: True
       - name: Install dependencies
         run: |
-          uv pip install requests
+          uv sync
       - name: Get release name
         id: get_name
         run: |

--- a/.github/workflows/maestro_run-tests.yaml
+++ b/.github/workflows/maestro_run-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --all-extras
     - name: Check code format and style
       run: |
         uv run ruff check

--- a/.github/workflows/maestro_run-tests.yaml
+++ b/.github/workflows/maestro_run-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         activate-environment: true
     - name: Install dependencies
       run: |
-        uv pip install -e .[crewai]
+        uv sync
     - name: Check code format and style
       run: |
         uv run ruff check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ source .venv/bin/activate  # On Unix/macOS
 
 3. Install dependencies:
 ```bash
-uv sync
+uv sync --all-extras
 ```
 
 4. (optional) Enable pre-commit
@@ -156,7 +156,7 @@ source .venv/bin/activate  # On Unix/macOS
 3. **Install dependencies:** Install all project dependencies:
 
 ```bash
-uv sync
+uv sync --all-extras
 ```
 
 4. **Setup environmental variables:** Make a copy of `.env.example` file in the repository's root and name it `.env`. Uncomment and update the parameters in the `.env` as needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ source .venv/bin/activate  # On Unix/macOS
 
 3. Install dependencies:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 4. (optional) Enable pre-commit
@@ -52,7 +52,7 @@ We use [ruff](https://docs.astral.sh/ruff/) for code formatting and linting. To 
 
 1. Install development dependencies:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 2. Run the formatter:
@@ -94,7 +94,7 @@ git commit -m "feat(agent): add new agent type"
 
 ## Pull Request Process
 
-1. Ensure all dependencies are installed (`uv pip install -e .`).
+1. Ensure all dependencies are installed (`uv sync`).
 2. Run the test suite (`uv run pytest`).
 3. Run the formatter (`uv run ruff format`).
 4. Run the linter (`uv run ruff check --fix`).
@@ -156,7 +156,7 @@ source .venv/bin/activate  # On Unix/macOS
 3. **Install dependencies:** Install all project dependencies:
 
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 4. **Setup environmental variables:** Make a copy of `.env.example` file in the repository's root and name it `.env`. Uncomment and update the parameters in the `.env` as needed.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd maestro
 
 2. Install development dependencies:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 3. Run tests:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd maestro
 
 2. Install development dependencies:
 ```bash
-uv sync
+uv sync --all-extras
 ```
 
 3. Run tests:

--- a/demos/CONTRIBUTING.md
+++ b/demos/CONTRIBUTING.md
@@ -20,7 +20,7 @@ source .venv/bin/activate  # On Unix/macOS
 
 3. Install dependencies:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 4. (optional) Enable pre-commit
@@ -52,7 +52,7 @@ We use [ruff](https://docs.astral.sh/ruff/) for code formatting and linting. To 
 
 1. Install development dependencies:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
 2. Run the formatter:
@@ -94,7 +94,7 @@ git commit -m "feat(agent): add new agent type"
 
 ## Pull Request Process
 
-1. Ensure all dependencies are installed (`uv pip install -e .`).
+1. Ensure all dependencies are installed (`uv sync`).
 2. Run the test suite (`uv run pytest`).
 3. Run the formatter (`uv run ruff format`).
 4. Run the linter (`uv run ruff check --fix`).
@@ -143,7 +143,7 @@ uv venv --python 3.12
 source .venv/bin/activate  # On Unix/macOS
 # or
 .venv\Scripts\activate  # On Windows
-uv pip install -e .
+uv sync
 ```
 
 ### 3. Configure Environment Variables
@@ -250,7 +250,7 @@ spec:
 
 ### Debugging Tips
 
-- Ensure all dependencies are installed (`uv pip install -e .`).
+- Ensure all dependencies are installed (`uv sync`).
 - Check for missing agents (`agent_store.json` must contain registered agents).
 - Validate YAML schemas using `maestro validate` before running workflows.
 

--- a/demos/CONTRIBUTING.md
+++ b/demos/CONTRIBUTING.md
@@ -20,7 +20,7 @@ source .venv/bin/activate  # On Unix/macOS
 
 3. Install dependencies:
 ```bash
-uv sync
+uv sync --all-extras
 ```
 
 4. (optional) Enable pre-commit
@@ -143,7 +143,7 @@ uv venv --python 3.12
 source .venv/bin/activate  # On Unix/macOS
 # or
 .venv\Scripts\activate  # On Windows
-uv sync
+uv sync --all-extras
 ```
 
 ### 3. Configure Environment Variables

--- a/demos/agents/crewai/activity_planner/README.md
+++ b/demos/agents/crewai/activity_planner/README.md
@@ -5,14 +5,11 @@ This demo shows how to use Maestro with CrewAI to create an activity planner age
 ## Prerequisites
 
 * Python 3.12 or higher
-* [uv](https://github.com/astral-sh/uv) package manager
 * [maestro](https://github.com/AI4quantum/maestro) installed
 
 ## Setup
 
 1. Install dependencies:
 ```bash
-cd maestro
-uv pip install -e .
-cd -
+pip install "maestro[crewai] @ git+https://github.com/AI4quantum/maestro.git@v0.1.0"
 ```

--- a/demos/workflows/activity-planner-crewai.ai/README.md
+++ b/demos/workflows/activity-planner-crewai.ai/README.md
@@ -12,7 +12,7 @@ This demo shows how to use Maestro with CrewAI to create a workflow that plans a
 
 * Install maestro:
     ```bash
-    pip install git+https://github.com/AI4quantum/maestro.git@v0.1.0
+    pip install "maestro[crewai] @ git+https://github.com/AI4quantum/maestro.git@v0.1.0"
     ```
 
 ## Running

--- a/demos/workflows/common/doctor.sh
+++ b/demos/workflows/common/doctor.sh
@@ -7,7 +7,7 @@ if uv run which maestro &> /dev/null; then
     echo "✅ Maestro CLI is installed: $(uv run which maestro)"
 else
     echo "❌ Maestro CLI is not installed. Please run:"
-    echo "   uv pip install -e ."
+    echo "   uv sync"
 fi
 
 # Check workflow directory structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
 [project.scripts]
 maestro = "maestro.cli.run_maestro:__run_cli"
 
+[tool.uv]
+package = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["maestro*"]

--- a/src/maestro/agents/meta_agent/doctor.sh
+++ b/src/maestro/agents/meta_agent/doctor.sh
@@ -7,7 +7,7 @@ if uv run which maestro &> /dev/null; then
     echo "✅ Maestro CLI is installed: $(uv run which maestro)"
 else
     echo "❌ Maestro CLI is not installed. Please run:"
-    echo "   uv pip install -e ."
+    echo "   uv sync"
 fi
 
 # Check meta-agent directory structure

--- a/tools/run-demos.sh
+++ b/tools/run-demos.sh
@@ -30,7 +30,7 @@ if command -v uv &>/dev/null; then
         echo "✅ Found maestro module via uv"
     else
         echo "🔄 Installing maestro via uv..."
-        uv pip install -e .
+        uv sync
         if uv run which maestro &>/dev/null; then
             MAESTRO_CMD="uv run maestro"
             echo "✅ Successfully installed maestro via uv"


### PR DESCRIPTION
Fixes #592 (See there for the reasoning)

Replaces `uv pip install -e .` with `uv sync` in the docs, scripts and CI.

Also fixes a bug in `pyproject.toml` that only surfaces when using `uv sync` and not `uv pip install -e .` or `uv build`