### PR TITLE
chore: remove version from title

### DIFF
--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
-          name: ${{ needs.build.outputs.release_name }} – ${{ github.ref_name }}
+          name: ${{ needs.build.outputs.release_name }}
 
   followup-pr:
     needs: [build, release]


### PR DESCRIPTION
remove version from release title.


fixes #607
- should be fixed as we have updated the pyproject, readme manually b/c of manual release