### PR TITLE
bug: Update start stop to Support Dedicated Builder API and Frontend

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -94,11 +94,18 @@ async def chat_builder_agent(message: ChatMessage):
         if resp.status_code != 200:
             raise Exception(resp.text)
 
-        agent_yaml = resp.json().get("response", "")
+        full_output = resp.json().get("response", "")
+        extracted_yaml = ""
+        if "```yaml" in full_output:
+            extracted_yaml = (
+                full_output.split("```yaml", 1)[-1].split("```", 1)[0].strip()
+            )
+        elif "```" in full_output:
+            extracted_yaml = full_output.split("```", 1)[-1].split("```", 1)[0].strip()
 
         return {
-            "response": agent_yaml,
-            "yaml_files": [{"name": "generated.yaml", "content": agent_yaml}],
+            "response": full_output,
+            "yaml_files": [{"name": "agents.yaml", "content": extracted_yaml}],
             "chat_id": str(uuid.uuid4()),
         }
     except Exception as e:

--- a/builder/src/services/api.ts
+++ b/builder/src/services/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'http://localhost:8000'
+const API_BASE_URL = 'http://localhost:8001'
 
 export interface ChatMessage {
   content: string

--- a/stop.sh
+++ b/stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Maestro Stop Script
-# Safely stops both the API and Builder frontend services
+# Safely stops the Builder frontend and Workflow backend services
 
 set -e
 
@@ -12,22 +12,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Function to print colored output
-print_status() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
-
-print_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
-}
-
-print_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
-}
-
-print_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
+print_status() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -35,157 +23,131 @@ cd "$SCRIPT_DIR"
 
 # Function to check if a process is running
 is_process_running() {
-    local pid=$1
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-        return 0  # Process is running
-    else
-        return 1  # Process is not running
-    fi
+  local pid=$1
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then return 0; else return 1; fi
 }
 
 # Function to safely stop a process
 stop_process() {
-    local pid_file=$1
-    local service_name=$2
-    local port=$3
-    
-    if [ -f "$pid_file" ]; then
-        local pid=$(cat "$pid_file")
-        
-        if is_process_running "$pid"; then
-            print_status "Stopping $service_name (PID: $pid)..."
+  local pid_file=$1
+  local service_name=$2
+  local port=$3
+
+  if [ -f "$pid_file" ]; then
+    local pid=$(cat "$pid_file")
+    if is_process_running "$pid"; then
+      print_status "Stopping $service_name (PID: $pid)..."
             
-            # Try graceful shutdown first
-            kill "$pid" 2>/dev/null || true
+    # Try graceful shutdown first
+      kill "$pid" 2>/dev/null || true
             
             # Wait for graceful shutdown
             local wait_count=0
             while is_process_running "$pid" && [ $wait_count -lt 10 ]; do
-                sleep 1
-                wait_count=$((wait_count + 1))
-            done
+        sleep 1
+      done
             
-            # Force kill if still running
-            if is_process_running "$pid"; then
-                print_warning "$service_name didn't stop gracefully, forcing termination..."
-                kill -9 "$pid" 2>/dev/null || true
-                sleep 1
-            fi
-            
-            if is_process_running "$pid"; then
-                print_error "Failed to stop $service_name (PID: $pid)"
-                return 1
-            else
-                print_success "$service_name stopped successfully"
-                rm -f "$pid_file"
-                return 0
-            fi
-        else
-            print_warning "$service_name is not running (PID: $pid)"
-            rm -f "$pid_file"
-            return 0
-        fi
-    else
-        print_warning "PID file for $service_name not found"
+    # Force kill if still running
+      if is_process_running "$pid"; then
+        print_warning "$service_name didn't stop gracefully, forcing..."
+        kill -9 "$pid" 2>/dev/null || true
+        sleep 1
+      fi
+      if is_process_running "$pid"; then
+        print_error "Failed to stop $service_name (PID: $pid)"
+        return 1
+      else
+        print_success "$service_name stopped successfully"
+        rm -f "$pid_file"
         return 0
+      fi
+    else
+      print_warning "$service_name is not running (PID: $pid)"
+      rm -f "$pid_file"
     fi
+  else
+    print_warning "PID file for $service_name not found"
+  fi
+  return 0
 }
 
 # Function to check if a port is in use
 check_port() {
-    local port=$1
-    if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
-        return 0  # Port is in use
-    else
-        return 1  # Port is free
-    fi
+  local port=$1
+  lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1
 }
 
-# Function to kill processes by port
 kill_process_by_port() {
-    local port=$1
-    local service_name=$2
-    
-    if check_port "$port"; then
-        print_warning "$service_name is still running on port $port, attempting to kill by port..."
-        local pids=$(lsof -ti :$port 2>/dev/null || true)
-        
-        if [ -n "$pids" ]; then
-            for pid in $pids; do
-                print_status "Killing process $pid on port $port..."
-                kill -9 "$pid" 2>/dev/null || true
-            done
-            
-            # Wait a moment and check again
-            sleep 2
-            if check_port "$port"; then
-                print_error "Failed to stop $service_name on port $port"
-                return 1
-            else
-                print_success "$service_name stopped on port $port"
-                return 0
-            fi
-        else
-            print_error "Could not find process using port $port"
-            return 1
-        fi
-    else
-        print_success "$service_name is not running on port $port"
+  local port=$1
+  local service_name=$2
+
+  if check_port "$port"; then
+    print_warning "$service_name is still running on port $port, killing..."
+    local pids=$(lsof -ti :$port 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+      for pid in $pids; do
+        print_status "Killing process $pid on port $port..."
+        kill -9 "$pid" 2>/dev/null || true
+      done
+      sleep 2
+      if check_port "$port"; then
+        print_error "Failed to stop $service_name on port $port"
+        return 1
+      else
+        print_success "$service_name stopped on port $port"
         return 0
+      fi
+    else
+      print_error "Could not find process on port $port"
+      return 1
     fi
+  else
+    print_success "$service_name not running on port $port"
+    return 0
+  fi
 }
 
-print_status "Stopping Maestro services..."
+print_status "Stopping Maestro Builder services..."
 
-# Stop API service
-if [ -f "logs/api.pid" ]; then
-    stop_process "logs/api.pid" "API service" 8000
-else
-    print_warning "API PID file not found, checking port 8000..."
-    kill_process_by_port 8000 "API service"
-fi
-
-# Stop Builder frontend
+# Stop Builder Frontend
 if [ -f "logs/builder.pid" ]; then
-    stop_process "logs/builder.pid" "Builder frontend" 5174
-    stop_process "logs/builder.pid" "Builder frontend" 5174
+  stop_process "logs/builder.pid" "Builder frontend" 5174
 else
-    print_warning "Builder PID file not found, checking port 5174..."
-    kill_process_by_port 5174 "Builder frontend"
+  print_warning "Builder PID file not found, checking port 5174..."
+  kill_process_by_port 5174 "Builder frontend"
 fi
 
-# Final verification
-echo ""
-print_status "Verifying services are stopped..."
+# Stop Workflow Backend (optional second port)
+kill_process_by_port 8001 "Workflow LLM backend"
 
-api_stopped=true
+# Catch any lingering Vite hot-reload ports
+kill_process_by_port 5173 "Vite dev server (hot reload)"
+
+# Final Verification
+echo ""
+print_status "Verifying all services are stopped..."
+
 builder_stopped=true
 
-if check_port 8000; then
-    print_error "API service is still running on port 8000"
-    api_stopped=false
-fi
-
 if check_port 5174 || check_port 5173; then
-    print_error "Builder frontend is still running on port 5174 or 5173"
-    builder_stopped=false
+  print_error "Builder frontend is still running on port 5174 or 5173"
+  builder_stopped=false
 fi
 
-if [ "$api_stopped" = true ] && [ "$builder_stopped" = true ]; then
-    print_success "All Maestro services have been stopped successfully!"
+if check_port 8001; then
+  print_error "Workflow backend is still running on port 8001"
+  builder_stopped=false
+fi
+
+if [ "$builder_stopped" = true ]; then
+  print_success "All Maestro Builder services stopped successfully!"
 else
-    print_error "Some services may still be running. You may need to manually stop them."
-    exit 1
+  print_error "Some services may still be running. Manual kill may be needed."
+  exit 1
 fi
 
-# Clean up log files if they exist
-if [ -f "logs/api.log" ]; then
-    print_status "API logs are available at: logs/api.log"
-fi
-
-if [ -f "logs/builder.log" ]; then
-    print_status "Builder logs are available at: logs/builder.log"
-fi
+# Show logs if available
+[ -f "logs/builder.log" ] && print_status "Builder logs at: logs/builder.log"
 
 echo ""
-echo "To start services again, run: ./start.sh" 
+echo "To restart: ./start.sh"


### PR DESCRIPTION
Isolated Builder Backend from maestro serve: Assigned port 8001 to run api/main.py (Builder backend), allowing maestro serve to continue using port 8000.
- ./start.sh needs to point to overall maestro venv to support backend reqs also

Updated stop.sh:
- Gracefully shuts down Builder backend (8001) and frontend (5174).