### PR TITLE
bug: set correct CI perms for releases

### DIFF
--- a/.github/workflows/maestro_build_upload_images.yaml
+++ b/.github/workflows/maestro_build_upload_images.yaml
@@ -16,6 +16,8 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
     outputs:
       version: ${{ steps.build_push.outputs.version }}
     steps:
@@ -55,6 +57,8 @@ jobs:
   upload-manifest:
     needs: build-upload
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -104,6 +104,8 @@ jobs:
   followup-pr:
     needs: [build, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /usr/src/app
 
-ARG MAESTRO_VERSION="0.3.1"
+ARG MAESTRO_VERSION="0.3.0"
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestro"
-version = "0.3.1"
+version = "0.3.0"
 description = "A multi-agent platform with the vision to facilitate deploy and run AI agents."
 authors = [
     {name = "IBM"}


### PR DESCRIPTION
permission has to be granted individually to any job based on how it uses `secrets.GITHUB_TOKEN`, by default only `read` is allowed on orgs but for users it's `write`

This extended #642 to also allow write for opening a PR and package write for the docker image CI

I also reverted back to `0.3.0` so we can do a fresh `v0.3.0` release rather than a patch