### PR TITLE
bug: release ci need separate pr write perms

### DIFF
--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
As seen in the latest release CI https://github.com/AI4quantum/maestro/actions/runs/16351669752/job/46200013327#step:5:149

creating PRs requires a separate permissions config than creating a branch, due to this bug I had to manually open #644 
