### PR TITLE
bug: remove crewai agent 

### DIFF
--- a/operator/Dockerfile-engine
+++ b/operator/Dockerfile-engine
@@ -67,7 +67,8 @@ RUN pip3 install --no-cache-dir --upgrade \
     pydantic-ai \
     logfire \
     litellm \
-    dspy
+    dspy \
+    ddgs    
 
 COPY ./src ./src
 COPY ./operator/entrypoint_api.sh .

--- a/operator/Dockerfile-engine
+++ b/operator/Dockerfile-engine
@@ -54,7 +54,6 @@ RUN pip3 install --no-cache-dir --upgrade \
     jsonschema \
     docopt-ng \
     langchain-community \
-    duckduckgo-search \
     streamlit \
     streamlit-mermaid \
     psutil \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "openapi>=2.0.0",
     "openai-agents[litellm]>=0.0.14",
     "pycron>=3.1.2",
-    "beeai-framework>=0.1.17",
+    "beeai-framework>=0.1.31",
     "slack_sdk>=3.35.0",
     "nest-asyncio>=1.6.0",
     "pydantic-ai[logfire]>=0.1.8",
@@ -31,12 +31,6 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "dspy>=2.6.27",
     "kubernetes>=33.1.0",
-]
-
-[project.optional-dependencies]
-crewai = [
-    "crewai",
-    "litellm==1.67.5"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "dspy>=2.6.27",
     "kubernetes>=33.1.0",
+    "ddgs>=9.4.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "jsonschema>=4.23.0",
     "docopt-ng>=0.9.0",
     "langchain-community>=0.3.16",
-    "duckduckgo-search>=7.3.0",
     "streamlit>=1.44.0",
     "streamlit-mermaid>=0.3.0",
     "psutil>=7.0.0",

--- a/tests/agents/crewai_agent/test_crewai.py
+++ b/tests/agents/crewai_agent/test_crewai.py
@@ -37,4 +37,4 @@ class CrewAITest(TestCase):
 
 if __name__ == "__main__":
     crewtest = CrewAITest()
-    crewtest.test_agent_runs()
+    # crewtest.test_agent_runs()

--- a/tests/agents/crewai_agent/test_crewai.py
+++ b/tests/agents/crewai_agent/test_crewai.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 
 class CrewAITest(TestCase):
-    def test_agent_runs(self) -> None:
+    def disabled_test_agent_runs(self) -> None:
         agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__), "agents.yaml"))
         workflow_yaml = parse_yaml(
             os.path.join(os.path.dirname(__file__), "workflow.yaml")


### PR DESCRIPTION
Remove crewai optional dependency from pyproject.toml.  It is causing a conflict with beeai-framework.

#650 left open to fix or clean up the CrewAI agent.