### PR TITLE
project license as a toml table is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A multi-agent platform with the vision to facilitate deploy and r
 authors = [
     {name = "IBM"}
 ]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
 dependencies = [


### PR DESCRIPTION
Fixes #662

See the error when running uv sync on CI in maestro demos

https://github.com/AI4quantum/maestro-demos/actions/runs/16503394356/job/46667742064?pr=12

```
[stderr]
      /home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpIYgb8l/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82:
      SetuptoolsDeprecationWarning: `project.license` as a TOML table is
      deprecated
      !!
```

Updated guidelines [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)
