### PR TITLE
feat: enable llm url override via yaml spec

### DIFF
--- a/src/maestro/agents/beeai_agent.py
+++ b/src/maestro/agents/beeai_agent.py
@@ -7,6 +7,7 @@ import tempfile
 import requests
 import json
 
+from beeai_framework.adapters.ollama import OllamaChatModel
 from beeai_framework.agents.tool_calling import ToolCallingAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.tools.code import PythonTool, LocalPythonStorage, SandboxTool
@@ -245,9 +246,14 @@ class BeeAILocalAgent(Agent):
         self.agent = None
 
     async def _create_agent(self):
-        llm = ChatModel.from_name(
-            self.agent_model, base_url=self.agent["spec"].get("url")
-        )
+        if len(self.agent_model.split("/")) < 2:
+            llm = OllamaChatModel(
+                self.agent_model, base_url=self.agent["spec"].get("url")
+            )
+        else:
+            llm = ChatModel.from_name(
+                self.agent_model, base_url=self.agent["spec"].get("url")
+            )
 
         templates: dict[str, Any] = {
             "user": user_template_func,

--- a/src/maestro/agents/beeai_agent.py
+++ b/src/maestro/agents/beeai_agent.py
@@ -8,6 +8,7 @@ import requests
 import json
 
 from beeai_framework.agents.tool_calling import ToolCallingAgent
+from beeai_framework.backend import ChatModel
 from beeai_framework.tools.code import PythonTool, LocalPythonStorage, SandboxTool
 from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
@@ -16,7 +17,6 @@ from openai.types.beta.threads.runs import RunStep, RunStepDelta, ToolCall
 from typing import Any, Callable
 from pydantic import BaseModel
 
-from beeai_framework.adapters.ollama import OllamaChatModel
 from beeai_framework.agents import AgentExecutionConfig, AgentMeta
 from beeai_framework.emitter import Emitter, EmitterOptions, EventMeta
 from beeai_framework.errors import FrameworkError
@@ -245,7 +245,9 @@ class BeeAILocalAgent(Agent):
         self.agent = None
 
     async def _create_agent(self):
-        llm = OllamaChatModel(self.agent_model)
+        llm = ChatModel.from_name(
+            self.agent_model, base_url=self.agent["spec"].get("url")
+        )
 
         templates: dict[str, Any] = {
             "user": user_template_func,

--- a/src/maestro/agents/beeai_agent.py
+++ b/src/maestro/agents/beeai_agent.py
@@ -46,7 +46,9 @@ class BeeAIAgent(Agent):
         """
         super().__init__(agent)
 
-        url = f"{os.getenv('BEE_API')}/v1/assistants"
+        self.base_url = f"{agent['spec'].get('url', os.getenv('BEE_API'))}/v1"
+
+        url = f"{self.base_url}/assistants"
         headers = {
             "accept": "application/json",
             "Authorization": "Bearer sk-proj-testkey",
@@ -85,7 +87,8 @@ class BeeAIAgent(Agent):
         """
         self.print(f"Running {self.agent_name}...\n")
         client = OpenAI(
-            base_url=f"{os.getenv('BEE_API')}/v1", api_key=os.getenv("BEE_API_KEY")
+            base_url=f"{self.base_url}/v1",
+            api_key=os.getenv("BEE_API_KEY", "dummy_key"),
         )
         # TODO: Unused currently
         # assistant = client.beta.assistants.retrieve(self.agent_id)
@@ -108,7 +111,8 @@ class BeeAIAgent(Agent):
         """
         self.print(f"Running {self.agent_name}...\n")
         client = OpenAI(
-            base_url=f"{os.getenv('BEE_API')}/v1", api_key=os.getenv("BEE_API_KEY")
+            base_url=f"{self.base_url}/v1",
+            api_key=os.getenv("BEE_API_KEY", "dummy_key"),
         )
         # TODO: Unused currently
         # assistant = client.beta.assistants.retrieve(self.agent_id)

--- a/src/maestro/agents/openai_agent.py
+++ b/src/maestro/agents/openai_agent.py
@@ -54,8 +54,10 @@ class OpenAIAgent(MaestroAgent):
 
         spec_dict = agent_definition.get("spec", {})
         self.model_name: str = spec_dict.get("model", OPENAI_DEFAULT_MODEL)
-        self.base_url: str = os.getenv("OPENAI_BASE_URL", OPENAI_DEFAULT_URL)
-        self.api_key: Optional[str] = os.getenv("OPENAI_API_KEY")
+        self.base_url: str = spec_dict.get(
+            "url", os.getenv("OPENAI_BASE_URL", OPENAI_DEFAULT_URL)
+        )
+        self.api_key: Optional[str] = os.getenv("OPENAI_API_KEY", "dummy_key")
         self.uses_chat_completions: bool = self.base_url != OPENAI_DEFAULT_URL
         self.use_litellm: bool = (
             os.getenv("MAESTRO_OPENAI_USE_LITELLM", "false").lower() == "true"

--- a/tests/yamls/agents/funnier_local_agents.yaml
+++ b/tests/yamls/agents/funnier_local_agents.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: funnier-example
 spec:
-  model: llama3.1
+  model: ollama/llama3.1
   framework: beeai
   mode: local
   instructions: you are a joke telling agent

--- a/tests/yamls/agents/funnier_local_agents.yaml
+++ b/tests/yamls/agents/funnier_local_agents.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: funnier-example
 spec:
-  model: ollama/llama3.1
+  model: llama3.1
   framework: beeai
   mode: local
   instructions: you are a joke telling agent

--- a/tests/yamls/agents/simple_local_agent.yaml
+++ b/tests/yamls/agents/simple_local_agent.yaml
@@ -6,7 +6,7 @@ metadata:
     app: test-example
 spec:
 
-  model: llama3.1
+  model: ollama/llama3.1
   framework: beeai
   mode: local
   description: this is a test
@@ -24,7 +24,7 @@ metadata:
   labels:
     app: test-example
 spec:
-  model: llama3.1
+  model: ollama/llama3.1
   mode: local
   framework: beeai
   description: this is a test
@@ -42,7 +42,7 @@ metadata:
   labels:
     app: test-example
 spec:
-  model: llama3.1
+  model: ollama/llama3.1
   framework: beeai
   mode: local
   description: this is a test
@@ -60,7 +60,7 @@ metadata:
   labels:
     app: test-example
 spec:
-  model: llama3.1
+  model: ollama/llama3.1
   framework: beeai
   mode: local
   description: this is a test
@@ -78,7 +78,7 @@ metadata:
   labels:
     app: test-example
 spec:
-  model: llama3.1
+  model: ollama/llama3.1
   framework: beeai
   mode: local
   description: this is a test


### PR DESCRIPTION
Fixes #657 

This removes the reliance on env vars for beeai and openai agents by allowing the config of the api url via the yaml and not just the env var and setting a dummy key by default if the api key env var is not set.
