### PR TITLE
enhancement/bug: allow validate to be accessible outside of repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ where = ["src"]
 include = ["maestro*"]
 
 [tool.setuptools.package-data]
-"maestro" = ["images/*.png"]
+"maestro" = ["images/*.png", "schemas/*.json"]
 
 [tool.pytest.ini_options]
 addopts = "-v -s --ignore=framework"

--- a/src/maestro/cli/commands.py
+++ b/src/maestro/cli/commands.py
@@ -17,6 +17,7 @@ import jsonschema
 import psutil
 
 from jsonschema.exceptions import ValidationError, SchemaError
+from importlib.resources import files
 
 from maestro.deploy import Deploy
 from maestro.workflow import Workflow, create_agents
@@ -160,17 +161,16 @@ class ValidateCmd(Command):
         if isinstance(yaml_data, list) and len(yaml_data) > 0:
             yaml_data = yaml_data[0]
         kind = yaml_data.get("kind")
-        project_root = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "../../../")
-        )
         if kind == "Agent":
-            return os.path.join(project_root, "schemas/agent_schema.json")
+            return str(files("maestro").joinpath("schemas/agent_schema.json"))
         elif kind == "Tool":
-            return os.path.join(project_root, "schemas/tool_schema.json")
+            return str(files("maestro").joinpath("schemas/tool_schema.json"))
         elif kind == "MCPTool":
-            return os.path.join(project_root, "schemas/tool_toolhive_schema_full.json")
+            return str(
+                files("maestro").joinpath("schemas/tool_toolhive_schema_full.json")
+            )
         elif kind == "Workflow":
-            return os.path.join(project_root, "schemas/workflow_schema.json")
+            return str(files("maestro").joinpath("schemas/workflow_schema.json"))
         elif kind == "WorkflowRun":
             Console.ok("WorkflowRun is not supported")
             return None
@@ -184,13 +184,14 @@ class ValidateCmd(Command):
         Console.print(f"validating {yaml_file} with schema {schema_file}")
         if schema_file is None:
             # Try to discover the schema file based on the yaml file
-            project_root = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "../../../")
-            )
             if "agents.yaml" in yaml_file:
-                schema_file = os.path.join(project_root, "schemas/agent_schema.json")
+                schema_file = str(
+                    files("maestro").joinpath("schemas/agent_schema.json")
+                )
             elif "workflow.yaml" in yaml_file:
-                schema_file = os.path.join(project_root, "schemas/workflow_schema.json")
+                schema_file = str(
+                    files("maestro").joinpath("schemas/workflow_schema.json")
+                )
             else:
                 raise RuntimeError(
                     "Could not determine schema file from yaml file name"

--- a/src/maestro/schemas/agent_schema.json
+++ b/src/maestro/schemas/agent_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/AI4quantum/maestro/schemas/agent_schema.json",
+  "$id": "https://github.com/AI4quantum/maestro/src/maestro/schemas/agent_schema.json",
   "title": "Maestro Agent",
   "description": "A schema for defining Maestro workflows in YAML or JSON",
   "type": "object",

--- a/src/maestro/schemas/tool_schema.json
+++ b/src/maestro/schemas/tool_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/AI4quantum/maestro/schemas/tool_schema.json",
+  "$id": "https://github.com/AI4quantum/maestro/src/maestro/schemas/tool_schema.json",
   "title": "Maestro Tool",
   "description": "A schema for defining Maestro MetaAgent tool in YAML or JSON",
   "type": "object",

--- a/src/maestro/schemas/tool_toolhive_schema_full.json
+++ b/src/maestro/schemas/tool_toolhive_schema_full.json
@@ -1,6 +1,6 @@
 {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "https://github.com/AI4quantum/maestro/schemas/tool_toolhive_schema_full.json",
+            "$id": "https://github.com/AI4quantum/maestro/src/maestro/schemas/tool_toolhive_schema_full.json",
             "title": "Maestro Tool",
             "type": "object",  
             "description": "MCPServer is the Schema for the mcpservers API",

--- a/src/maestro/schemas/workflow_schema.json
+++ b/src/maestro/schemas/workflow_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/AI4quantum/maestro/schemas/workflow_schema.json",
+  "$id": "https://github.com/AI4quantum/maestro/src/maestro/schemas/workflow_schema.json",
   "title": "Maestro Workflow",
   "description": "A schema for defining Maestro workflows in YAML or JSON",
   "type": "object",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -6,19 +6,19 @@
 import os
 import unittest
 from unittest import TestCase, mock
+from importlib.resources import files
 
 from maestro.cli.commands import CLI
 
 
 class TestCommand(TestCase):
     TEST_FIXTURES_ROOT_PATH = os.path.join(os.path.dirname(__file__), "..")
-    SCHEMAS_ROOT_PATH = os.path.join(os.path.dirname(__file__), "../../schemas")
 
     def get_fixture(self, file_name):
         return os.path.join(self.TEST_FIXTURES_ROOT_PATH, file_name)
 
     def get_schema(self, file_name):
-        return os.path.join(self.SCHEMAS_ROOT_PATH, file_name)
+        return str(files("maestro").joinpath(f"schemas/{file_name}"))
 
 
 # `deploy` commmand tests

--- a/tests/integration/dry_run/test_dry_run.py
+++ b/tests/integration/dry_run/test_dry_run.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright © 2025 IBM
 
-import os
 import subprocess
 import traceback
 import unittest
 
 from unittest import TestCase
+from importlib.resources import files
 
 
 def _maestro(*args) -> (str, int):
@@ -35,12 +35,11 @@ class TestCommand(TestCase):
     def setUp(self):
         self.agents_yaml_file = "tests/yamls/agents/simple_agent.yaml"
         self.workflow_yaml_file = "tests/yamls/workflows/simple_workflow.yaml"
-        project_root = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "../../..")
+        self.agent_schema_file = str(
+            files("maestro").joinpath("schemas/agent_schema.json")
         )
-        self.agent_schema_file = os.path.join(project_root, "schemas/agent_schema.json")
-        self.workflow_schema_file = os.path.join(
-            project_root, "schemas/workflow_schema.json"
+        self.workflow_schema_file = str(
+            files("maestro").joinpath("schemas/workflow_schema.json")
         )
 
     def tearDown(self):


### PR DESCRIPTION
fixes #665 

moved scehmas into package resources so we can bundle them in pyproject and allow maestro validate to work outside of repo. 