### PR TITLE
fix: maestro-cli docker image was mistagged

### DIFF
--- a/.github/workflows/maestro_build_upload_images.yaml
+++ b/.github/workflows/maestro_build_upload_images.yaml
@@ -76,14 +76,14 @@ jobs:
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
           docker manifest create ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }} \
-            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
-            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+            --amend ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}-arm64 &&
           docker manifest create ghcr.io/$GITHUB_ORG/maestro:latest \
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
           docker manifest create ghcr.io/$GITHUB_ORG/maestro-cli:latest \
-            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
-            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+            --amend ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}-arm64 &&
           docker manifest push ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}
           docker manifest push ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}
           docker manifest push ghcr.io/$GITHUB_ORG/maestro:latest


### PR DESCRIPTION
While working on adding a docker image publishing CI on maestro-knowledge I noticed there was a significant typo in our release ci. Due to this, the current `maestro-cli` image is actually just a copy of the `maestro` image. This will fix this in the next release