### PR TITLE
feat: Enable maestro-knowledge tool for maestro agent

### DIFF
--- a/tests/yamls/tools/maestro_knowlege_mcp.yaml
+++ b/tests/yamls/tools/maestro_knowlege_mcp.yaml
@@ -1,0 +1,34 @@
+apiVersion: maestro/v1alpha1
+kind: MCPTool
+metadata:
+  name: maestrok
+  namespace: default
+spec:
+  image: ghcr.io/akihikokuroda/maestro-knowledge:latest
+  transport: streamable-http
+  targetPort: 8030
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: '100m'
+      memory: '128Mi'
+    requests:
+      cpu: '50m'
+      memory: '64Mi'
+  podTemplateSpec:
+    spec:
+      volumes:
+        - name: cache
+          emptyDir: {}
+      containers:
+        - name: mcp
+          volumeMounts:
+            - mountPath: /app/cache
+              name: cache
+          securityContext:
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+


### PR DESCRIPTION
Enable maestro-knowledge for maestro agents.

The maestro-knowledge (ToolHive) MCP server is deployed in the kubernetes cluster by

```cmd
maestro create tests/yamls/tools/maestro_knowlege_mcp.yaml
```

The maestro agent can access to the tool by adding `maestrok` to the `tools` list in the agent yaml file.