### PR TITLE
feat: local mcp server registration

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -42,7 +42,8 @@ The syntax of the agent definition is defined in the [json schema](https://githu
   - **framework**: agent framework type.  Current supported agent frameworks are : "beeai", "crewai", "openai", "remotem", "custom" and "code"
   - **mode**: Remote or Local.  Some agents support agent remotely.  Remote is supported by "beeai" and "remote" 
   - **description**: Description of this agent
-  - **tools**: array of tool names or mcp server names. In the kubernetes cluster, the MCP servers deployed by `maestro create <tool.yaml>` or `ToolHive` listed here are enabled for this agent.  In the case of the MCP servers, all tools hosted by the server are enabled.
+  - **tools**: array of tool names or mcp server names. In the kubernetes cluster, the MCP servers deployed by `maestro create <tool.yaml>` or `ToolHive` listed here are enabled for this agent.  In the case of the MCP servers, all tools hosted by the server are enabled.  For local deployment, the MCP server can be registered in the file specified by "MCP_SERVER_LIST" environment variable.  The file contents should be a list of MCP servers and each server should have "name", "url", "transport" and "access_token".
+  
   - **instructions**: the instructions for the agent, can be a (multi-line) string, a url, or a file path. The file path is relative to where maestro is run
 
 ### Workflow

--- a/src/maestro/mcptool.py
+++ b/src/maestro/mcptool.py
@@ -37,7 +37,10 @@ def create_mcptools(tool_defs):
     json_data = []
     for tool_def in tool_defs:
         if kube:
-            create_mcptool(tool_def)
+            try:
+                create_mcptool(tool_def)
+            except Exception:
+                kube = False
         create_json(tool_def, json_data)
     if len(json_data):
         print(json_data)

--- a/src/maestro/mcptool.py
+++ b/src/maestro/mcptool.py
@@ -28,10 +28,16 @@ remoteKind = "RemoteMCPServer"
 
 def create_mcptools(tool_defs):
     # Load kubeconfig
-    config.load_kube_config()
+    kube = True
+    try:
+        config.load_kube_config()
+    except Exception:
+        kube = False
+
     json_data = []
     for tool_def in tool_defs:
-        create_mcptool(tool_def)
+        if kube:
+            create_mcptool(tool_def)
         create_json(tool_def, json_data)
     if len(json_data):
         print(json_data)

--- a/src/maestro/mcptool.py
+++ b/src/maestro/mcptool.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright © 2025 IBM
 
+import os
+import json
 from kubernetes import client, config
 
 # Define the plural and singular names for the custom resource
@@ -27,8 +29,20 @@ remoteKind = "RemoteMCPServer"
 def create_mcptools(tool_defs):
     # Load kubeconfig
     config.load_kube_config()
+    json_data = []
     for tool_def in tool_defs:
         create_mcptool(tool_def)
+        create_json(tool_def, json_data)
+    if len(json_data):
+        print(json_data)
+        json_file = os.getenv("MCP_SERVER_LIST")
+        if json_file:
+            if os.path.exists(json_file):
+                with open(json_file, "r") as f:
+                    current_data = json.load(f)
+                    json_data = current_data + json_data
+            with open(json_file, "w") as f:
+                json.dump(json_data, f)
 
 
 def create_mcptool(body):
@@ -63,3 +77,14 @@ def create_mcptool(body):
         group, version, namespace, plural, body
     )
     print(f"MCP tool: {api_response['metadata']['name']} successfully created")
+
+
+def create_json(body, list):
+    if body["spec"].get("url"):
+        json_data = {
+            "name": body["metadata"]["name"],
+            "url": body["spec"]["url"].replace("/mcp", ""),
+            "transport": body["spec"]["transport"],
+            "access_token": body["metadata"].get("token"),
+        }
+        list.append(json_data)

--- a/src/maestro/tool_utils.py
+++ b/src/maestro/tool_utils.py
@@ -84,16 +84,16 @@ def find_mcp_service(name):
             if secretName:
                 secret = v1.read_namespaced_secret(name=secretName, namespace="default")
                 if secret:
-                    accessToken = base64.b64decode(secret.data["MCP_ACCESS_TOKEN"]).decode(
-                        "utf-8"
-                    )
+                    accessToken = base64.b64decode(
+                        secret.data["MCP_ACCESS_TOKEN"]
+                    ).decode("utf-8")
             return (name, url, transport, url, accessToken)
-    except Exception as e:
+    except Exception:
         None
 
     # local MCP server list
     # Example Json file
-    #[
+    # [
     #    {
     #        "name": "server1",
     #        "url": "http://server1.example.com",
@@ -112,7 +112,7 @@ def find_mcp_service(name):
     #        "transport": "stdio",
     #        "access_token": null
     #    }
-    #]
+    # ]
 
     json_file = os.getenv("MCP_SERVER_LIST")
     if json_file:
@@ -121,7 +121,13 @@ def find_mcp_service(name):
 
         for server in server_list:
             if server.get("name") == name:
-                return server.get("name"), server.get("url"), server.get("transport"), server.get("url"), server.get("access_token")
+                return (
+                    server.get("name"),
+                    server.get("url"),
+                    server.get("transport"),
+                    server.get("url"),
+                    server.get("access_token"),
+                )
 
     return None, None, None, None, None
 

--- a/src/maestro/tool_utils.py
+++ b/src/maestro/tool_utils.py
@@ -84,10 +84,10 @@ def find_mcp_service(name):
                 name = remote_crd["spec"]["name"]
                 if url.endswith("/"):
                     url = url[:-1]
-                    if url.endswith("/mcp"):
-                        url = url[: -len("/mcp")]
-                    elif url.endswith("/sse"):
-                        url = url[: -len("/sse")]
+                if url.endswith("/mcp"):
+                    url = url[: -len("/mcp")]
+                elif url.endswith("/sse"):
+                    url = url[: -len("/sse")]
                 accessToken = None
                 secretName = remote_crd["spec"].get("secretName")
                 if secretName:

--- a/src/maestro/tool_utils.py
+++ b/src/maestro/tool_utils.py
@@ -51,12 +51,19 @@ def find_mcp_service(name):
             for service in services.items:
                 # Fetch the MCPServer CRD instance
                 crd = apis.get_namespaced_custom_object(
-                    group=group, version=version, name=name, namespace=namespace, plural=plural
+                    group=group,
+                    version=version,
+                    name=name,
+                    namespace=namespace,
+                    plural=plural,
                 )
                 if crd:
                     transport = crd["spec"]["transport"]
                     external = None
-                    if service.spec.type == "NodePort" and service.spec.ports[0].node_port:
+                    if (
+                        service.spec.type == "NodePort"
+                        and service.spec.ports[0].node_port
+                    ):
                         external = f"http://127.0.0.1:{service.spec.ports[0].node_port}"
                     return (
                         service.metadata.name,
@@ -91,14 +98,16 @@ def find_mcp_service(name):
                 accessToken = None
                 secretName = remote_crd["spec"].get("secretName")
                 if secretName:
-                    secret = v1.read_namespaced_secret(name=secretName, namespace="default")
+                    secret = v1.read_namespaced_secret(
+                        name=secretName, namespace="default"
+                    )
                     if secret:
                         accessToken = base64.b64decode(
                             secret.data["MCP_ACCESS_TOKEN"]
                         ).decode("utf-8")
                 return (name, url, transport, url, accessToken)
-    except Exception:
-        None
+        except Exception:
+            None
 
     # local MCP server list
     # Example Json file

--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2025 IBM
+
+import os
+import yaml
+import unittest
+from unittest import TestCase
+from maestro.tool_utils import find_mcp_service
+
+class Test_tool_utils(TestCase):
+    mcp_server_list = "mcp_server_list.json"
+    def setUp(self):
+        os.environ["MCP_SERVER_LIST"] = self.mcp_server_list
+        with open(self.mcp_server_list, "w") as f:
+            contents = """
+[
+    {
+        "name": "slack",
+        "url": "http://localhost:30055",
+        "transport": "streamable-http",
+        "access_token": null
+    },
+    {
+        "name": "weather",
+        "url": "http://localhost:8000",
+        "transport": "streamable-http",
+        "access_token": null
+    }
+]
+            """
+            f.write(contents)
+
+    def tearDown(self):
+        os.remove(self.mcp_server_list)
+
+    def test_(self):
+        name, url, transport, external, token = find_mcp_service("weather")
+        assert name == "weather"
+        assert url == "http://localhost:8000"
+        assert transport == "streamable-http"
+        assert external == "http://localhost:8000"
+        assert token == None
+        
+        name, url, transport, external, token = find_mcp_service("none")
+        assert name == None
+        assert url == None
+        assert transport == None
+        assert external == None
+        assert token == None
+        
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 from maestro.tool_utils import find_mcp_service
 
 class Test_tool_utils(TestCase):
-    mcp_server_list = "mcp_server_list.json"
+    mcp_server_list = "test_mcp_server_list.json"
     def setUp(self):
         os.environ["MCP_SERVER_LIST"] = self.mcp_server_list
         with open(self.mcp_server_list, "w") as f:

--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -4,13 +4,14 @@
 # Copyright © 2025 IBM
 
 import os
-import yaml
 import unittest
 from unittest import TestCase
 from maestro.tool_utils import find_mcp_service
 
+
 class Test_tool_utils(TestCase):
     mcp_server_list = "test_mcp_server_list.json"
+
     def setUp(self):
         os.environ["MCP_SERVER_LIST"] = self.mcp_server_list
         with open(self.mcp_server_list, "w") as f:
@@ -41,14 +42,15 @@ class Test_tool_utils(TestCase):
         assert url == "http://localhost:8000"
         assert transport == "streamable-http"
         assert external == "http://localhost:8000"
-        assert token == None
-        
+        assert not token
+
         name, url, transport, external, token = find_mcp_service("none")
-        assert name == None
-        assert url == None
-        assert transport == None
-        assert external == None
-        assert token == None
-        
+        assert not name
+        assert not url
+        assert not transport
+        assert not external
+        assert not token
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fix #698 

MCP servers can be registered by a file that is specified by "MCP_SERVER_LIST" environment variable.
The file is in json format and it has list of MCP servers.
Each MCP server  has "name", "url", "transport" and "access_token"

Example of the file:
```
[                                                                                                                                                       
    {                                                                                                                                                   
        "name": "slack",                                                                                                                                
        "url": "http://localhost:30055",                                                                                                                
        "transport": "streamable-http",                                                                                                                 
        "access_token": null                                                                                                                            
    },                                                                                                                                                  
    {                                                                                                                                                   
        "name": "weather",                                                                                                                              
        "url": "http://localhost:8000",                                                                                                                 
        "transport": "streamable-http",                                                                                                                 
        "access_token": null                                                                                                                            
    }                                                                                                                                                   
]         
``` 