### PR TITLE
enhancement: dspy agent fix error handling

### DIFF
--- a/src/maestro/agents/dspy_agent.py
+++ b/src/maestro/agents/dspy_agent.py
@@ -82,7 +82,6 @@ class DspyAgent(BaseAgent):
             dspy_tools = []
             if self.tool_names and len(self.tool_names):
                 for tool_name in self.tool_names:
-                    # print(f"tool: {tool_name}")
                     dspy_tools.extend(
                         await get_mcp_tools(
                             tool_name, dspy.Tool.from_mcp_tool, mcp_stack
@@ -102,7 +101,7 @@ class DspyAgent(BaseAgent):
                     f"Response from {self.agent_name}: {result.process_result}\n"
                 )
                 return result.process_result
-            print("No response from Agent")
+            self.print("No response from Agent")
             return "Agent error"
         except Exception as e:
             self.print(f"Failed to execute dspy agent: {self.agent_name}: {e}\n")

--- a/src/maestro/agents/dspy_agent.py
+++ b/src/maestro/agents/dspy_agent.py
@@ -102,7 +102,7 @@ class DspyAgent(BaseAgent):
                 )
                 return result.process_result
             self.print("No response from Agent")
-            return "Agent error"
+            raise Exception("Agent error: No response from Agent")
         except Exception as e:
             self.print(f"Failed to execute dspy agent: {self.agent_name}: {e}\n")
             raise RuntimeError(f"Error executing Dspy agent {self.agent_name}") from e

--- a/src/maestro/agents/dspy_agent.py
+++ b/src/maestro/agents/dspy_agent.py
@@ -82,6 +82,7 @@ class DspyAgent(BaseAgent):
             dspy_tools = []
             if self.tool_names and len(self.tool_names):
                 for tool_name in self.tool_names:
+                    # print(f"tool: {tool_name}")
                     dspy_tools.extend(
                         await get_mcp_tools(
                             tool_name, dspy.Tool.from_mcp_tool, mcp_stack
@@ -89,13 +90,20 @@ class DspyAgent(BaseAgent):
                     )
             self.print(f"Running Dspy agent: {self.agent_name} with prompt: {prompt}\n")
             self.dspy_agent = dspy.ReAct(self.dspy_signature, dspy_tools)
+            result = {}
             try:
                 result = await self.dspy_agent.acall(user_request=prompt)
             except Exception as e:
                 print(f"Agent error: {e}")
-            self.print(f"Response from {self.agent_name}: {result.process_result}\n")
+
             await mcp_stack.aclose()
-            return result.process_result
+            if result and result.process_result:
+                self.print(
+                    f"Response from {self.agent_name}: {result.process_result}\n"
+                )
+                return result.process_result
+            print("No response from Agent")
+            return "Agent error"
         except Exception as e:
             self.print(f"Failed to execute dspy agent: {self.agent_name}: {e}\n")
             raise RuntimeError(f"Error executing Dspy agent {self.agent_name}") from e


### PR DESCRIPTION
fix #744 

If the llm is not available, this message comes out.
```
% uv run maestro run tests/yamls/agents/dspy_agent.yaml tests/yamls/workflows/dspy_workflow.yaml

🔍 [DEFAULT ROUTING] Step 'step1' using previous step output:
   Prompt: Where is the next Olympics game location?
💭 10-02-2025 14:29:01: Running Dspy agent: DSPyAgent with prompt: Where is the next Olympics game location?

/Users/akihikokuroda/development/repositories/AI4quantum/maestro/.venv/lib/python3.12/site-packages/httpx/_models.py:408: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
  headers, stream = encode_request(

No response from Agent
```