### PR TITLE
fix: update query agent to match latest maestro-knowledge api changes

### DIFF
--- a/src/maestro/agents/query_agent.py
+++ b/src/maestro/agents/query_agent.py
@@ -33,19 +33,19 @@ class QueryAgent(Agent):
             }
             tool_result = await client.call_tool("search", params)
 
-            if isinstance(tool_result.data, str):
+            try:
+                output = "\n\n".join(
+                    [doc["text"] for doc in json.loads(tool_result.data)]
+                )
+
+                answer = self.output_template.render(result=output, prompt=prompt)
+
+                self.print(f"Response from {self.agent_name}: {answer}\n")
+
+                return answer
+            except json.JSONDecodeError:
                 self.print(f"ERROR [QueryAgent {self.agent_name}]: {tool_result.data}")
                 return tool_result.data
-
-            output = "\n\n".join(
-                [doc["text"] for doc in json.loads(tool_result.content[0].text)]
-            )
-
-            answer = self.output_template.render(result=output, prompt=prompt)
-
-            self.print(f"Response from {self.agent_name}: {answer}\n")
-
-            return answer
 
     async def run_streaming(self, prompt: str) -> str:
         return await self.run(prompt)

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -63,7 +63,7 @@ class MockClient:
     async def call_tool(self, tool, params):
         return CallToolResult(
             content=[TextContent(type="text", text=json.dumps(db_data))],
-            data=db_data,
+            data=json.dumps(db_data),
             structured_content=None,
         )
 


### PR DESCRIPTION
https://github.com/AI4quantum/maestro-knowledge/pull/65 updated the `search` tool in maestro-knowledge to return a string instead of a dict for more consistent tool response types. Previously the tool would return a dict if valid or an error string if not. The query agent would check if it's a string and assume it's an error (which caused all queries to return an error).

This updates the result handling to instead use `json.loads` to parse the result for the expected dict and handles a `json.JSONDecodeError` if the result is an error string. 